### PR TITLE
Use React project Prettier configs

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -6,3 +6,5 @@ dist/*
 static/*
 src/speedscope/*
 src/tracerbench/*
+coverage
+.vscode

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,8 @@
 {
+  "bracketSpacing": false,
   "singleQuote": true,
-  "trailingComma": "es5"
+  "jsxBracketSameLine": true,
+  "printWidth": 80,
+  "parser": "babel",
+  "trailingComma": "all"
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -3,6 +3,5 @@
   "singleQuote": true,
   "jsxBracketSameLine": true,
   "printWidth": 80,
-  "parser": "babel",
   "trailingComma": "all"
 }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,6 @@
     "jest": "^26.0.1",
     "parcel": "2.0.0-alpha.3.2",
     "postcss-modules": "^2.0.0",
-    "prettier": "^1.19.1"
+    "prettier": "^2.0.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,6 @@
     "jest": "^26.0.1",
     "parcel": "2.0.0-alpha.3.2",
     "postcss-modules": "^2.0.0",
-    "prettier": "^2.0.5"
+    "prettier": "1.19.1"
   }
 }

--- a/src/App.js
+++ b/src/App.js
@@ -63,7 +63,7 @@ function App() {
 
   useEffect(() => {
     fetch(JSON_PATH)
-      .then((data) => data.json())
+      .then(data => data.json())
       .then((data: TimelineEvent[]) => {
         // Filter null entries and sort by timestamp.
         // I would not expect to have to do either of this,
@@ -80,7 +80,7 @@ function App() {
 
             let height = 0;
 
-            REACT_PRIORITIES.forEach((priority) => {
+            REACT_PRIORITIES.forEach(priority => {
               height += getPriorityHeight(processedData, priority);
             });
 

--- a/src/App.js
+++ b/src/App.js
@@ -1,9 +1,9 @@
 // @flow
 
-import type { TimelineEvent } from './speedscope/import/chrome';
-import type { PanAndZoomState } from './util/usePanAndZoom';
+import type {TimelineEvent} from './speedscope/import/chrome';
+import type {PanAndZoomState} from './util/usePanAndZoom';
 
-import { copy } from 'clipboard-js';
+import {copy} from 'clipboard-js';
 import React, {
   Fragment,
   useEffect,
@@ -11,15 +11,15 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import { unstable_batchedUpdates } from 'react-dom';
+import {unstable_batchedUpdates} from 'react-dom';
 import memoize from 'memoize-one';
 import usePanAndZoom from './util/usePanAndZoom';
 
-import { getHoveredEvent, getPriorityHeight } from './canvas/canvasUtils';
-import { renderCanvas } from './canvas/renderCanvas';
+import {getHoveredEvent, getPriorityHeight} from './canvas/canvasUtils';
+import {renderCanvas} from './canvas/renderCanvas';
 
 import prettyMilliseconds from 'pretty-ms';
-import { getBatchRange } from './util/getBatchRange';
+import {getBatchRange} from './util/getBatchRange';
 import EventTooltip from './EventTooltip';
 import preprocessData from './util/preprocessData';
 import preprocessFlamechart from './util/preprocessFlamechart';
@@ -33,7 +33,7 @@ import {
   HEADER_HEIGHT_FIXED,
 } from './canvas/constants';
 
-import { ContextMenu, ContextMenuItem, useContextMenu } from './context';
+import {ContextMenu, ContextMenuItem, useContextMenu} from './context';
 
 // TODO: Add import button but keep a static path until canvas layout is ready
 import JSON_PATH from 'url:../static/small-devtools.json';
@@ -63,7 +63,7 @@ function App() {
 
   useEffect(() => {
     fetch(JSON_PATH)
-      .then(data => data.json())
+      .then((data) => data.json())
       .then((data: TimelineEvent[]) => {
         // Filter null entries and sort by timestamp.
         // I would not expect to have to do either of this,
@@ -80,7 +80,7 @@ function App() {
 
             let height = 0;
 
-            REACT_PRIORITIES.forEach(priority => {
+            REACT_PRIORITIES.forEach((priority) => {
               height += getPriorityHeight(processedData, priority);
             });
 
@@ -91,9 +91,9 @@ function App() {
   }, []);
 
   return (
-    <div className={styles.App} style={{ backgroundColor: COLORS.PAGE_BG }}>
+    <div className={styles.App} style={{backgroundColor: COLORS.PAGE_BG}}>
       <AutoSizer>
-        {({ height, width }: { height: number, width: number }) => (
+        {({height, width}: {height: number, width: number}) => (
           <AutoSizedCanvas
             data={data}
             flamechart={flamechart}
@@ -108,7 +108,7 @@ function App() {
 }
 
 const copySummary = (data: ReactProfilerData | null, measure: ReactMeasure) => {
-  const { batchUID, duration, priority, timestamp, type } = measure;
+  const {batchUID, duration, priority, timestamp, type} = measure;
 
   const [startTime, stopTime] = getBatchRange(batchUID, priority, data);
 
@@ -118,20 +118,20 @@ const copySummary = (data: ReactProfilerData | null, measure: ReactMeasure) => {
       timestamp: prettyMilliseconds(timestamp),
       duration: prettyMilliseconds(duration),
       batchDuration: prettyMilliseconds(stopTime - startTime),
-    })
+    }),
   );
 };
 
 const zoomToBatch = (
   data: ReactProfilerData | null,
   measure: ReactMeasure,
-  state: PanAndZoomState
+  state: PanAndZoomState,
 ) => {
-  const { zoomTo } = state;
+  const {zoomTo} = state;
   if (!data || !zoomTo) {
     return;
   }
-  const { batchUID, priority } = measure;
+  const {batchUID, priority} = measure;
   const [startTime, stopTime] = getBatchRange(batchUID, priority, data);
   zoomTo(startTime, stopTime);
 };
@@ -171,7 +171,7 @@ function AutoSizedCanvas({
     schedulerCanvasHeight,
     data,
     flamechart,
-    state
+    state,
   );
   const [isContextMenuShown, setIsContextMenuShown] = useState<boolean>(false);
 
@@ -197,7 +197,7 @@ function AutoSizedCanvas({
         height,
         schedulerCanvasHeight,
         state,
-        hoveredEvent
+        hoveredEvent,
       );
     }
   });
@@ -211,50 +211,45 @@ function AutoSizedCanvas({
         width={width}
       />
       <ContextMenu id={CONTEXT_MENU_ID}>
-        {({ data, hoveredEvent }: ContextMenuContextData) => {
+        {({data, hoveredEvent}: ContextMenuContextData) => {
           if (hoveredEvent == null) {
             return null;
           }
-          const { event, flamechartNode, measure } = hoveredEvent;
+          const {event, flamechartNode, measure} = hoveredEvent;
           return (
             <Fragment>
               {event !== null && (
                 <ContextMenuItem
                   onClick={() => copy(event.componentName)}
-                  title="Copy component name"
-                >
+                  title="Copy component name">
                   Copy component name
                 </ContextMenuItem>
               )}
               {event !== null && (
                 <ContextMenuItem
                   onClick={() => copy(event.componentStack)}
-                  title="Copy component stack"
-                >
+                  title="Copy component stack">
                   Copy component stack
                 </ContextMenuItem>
               )}
               {measure !== null && (
                 <ContextMenuItem
                   onClick={() => zoomToBatch(data, measure, state)}
-                  title="Zoom to batch"
-                >
+                  title="Zoom to batch">
                   Zoom to batch
                 </ContextMenuItem>
               )}
               {measure !== null && (
                 <ContextMenuItem
                   onClick={() => copySummary(data, measure)}
-                  title="Copy summary"
-                >
+                  title="Copy summary">
                   Copy summary
                 </ContextMenuItem>
               )}
               {flamechartNode !== null && (
                 <ContextMenuItem
                   onClick={() => copy(flamechartNode.node.frame.file)}
-                  title="Copy file path"
-                >
+                  title="Copy file path">
                   Copy file path
                 </ContextMenuItem>
               )}
@@ -262,11 +257,10 @@ function AutoSizedCanvas({
                 <ContextMenuItem
                   onClick={() =>
                     copy(
-                      `line ${flamechartNode.node.frame.line}, column ${flamechartNode.node.frame.col}`
+                      `line ${flamechartNode.node.frame.line}, column ${flamechartNode.node.frame.col}`,
                     )
                   }
-                  title="Copy location"
-                >
+                  title="Copy location">
                   Copy location
                 </ContextMenuItem>
               )}

--- a/src/EventTooltip.js
+++ b/src/EventTooltip.js
@@ -112,7 +112,7 @@ function formatComponentStack(componentStack: string | null): string | null {
     return null;
   }
 
-  const lines = componentStack.split('\n').map((line) => line.trim());
+  const lines = componentStack.split('\n').map(line => line.trim());
   lines.shift();
 
   if (lines.length > 5) {

--- a/src/EventTooltip.js
+++ b/src/EventTooltip.js
@@ -1,7 +1,7 @@
 // @flow
 
-import type { PanAndZoomState } from './util/usePanAndZoom';
-import type { FlamechartFrame } from './speedscope/lib/flamechart';
+import type {PanAndZoomState} from './util/usePanAndZoom';
+import type {FlamechartFrame} from './speedscope/lib/flamechart';
 import type {
   ReactEvent,
   ReactMeasure,
@@ -11,9 +11,9 @@ import type {
 } from './types';
 
 import prettyMilliseconds from 'pretty-ms';
-import React, { Fragment, useLayoutEffect, useRef } from 'react';
-import { COLORS } from './canvas/constants';
-import { getBatchRange } from './util/getBatchRange';
+import React, {Fragment, useLayoutEffect, useRef} from 'react';
+import {COLORS} from './canvas/constants';
+import {getBatchRange} from './util/getBatchRange';
 import useSmartTooltip from './util/useSmartTooltip';
 import styles from './EventTooltip.css';
 
@@ -25,8 +25,8 @@ type Props = {|
   state: PanAndZoomState,
 |};
 
-export default function EventTooltip({ data, hoveredEvent, state }: Props) {
-  const { canvasMouseY, canvasMouseX } = state;
+export default function EventTooltip({data, hoveredEvent, state}: Props) {
+  const {canvasMouseY, canvasMouseX} = state;
 
   const tooltipRef = useSmartTooltip({
     mouseX: canvasMouseX,
@@ -37,7 +37,7 @@ export default function EventTooltip({ data, hoveredEvent, state }: Props) {
     return null;
   }
 
-  const { event, flamechartNode, measure } = hoveredEvent;
+  const {event, flamechartNode, measure} = hoveredEvent;
 
   if (event !== null) {
     switch (event.type) {
@@ -112,7 +112,7 @@ function formatComponentStack(componentStack: string | null): string | null {
     return null;
   }
 
-  const lines = componentStack.split('\n').map(line => line.trim());
+  const lines = componentStack.split('\n').map((line) => line.trim());
   lines.shift();
 
   if (lines.length > 5) {
@@ -130,8 +130,8 @@ const TooltipFlamechartNode = ({
   flamechartNode: FlamechartFrame,
   tooltipRef: Return<typeof useRef>,
 }) => {
-  const { end, node, start } = flamechartNode;
-  const { col, file, line, name } = node.frame;
+  const {end, node, start} = flamechartNode;
+  const {col, file, line, name} = node.frame;
   return (
     <div
       className={styles.Tooltip}
@@ -139,8 +139,7 @@ const TooltipFlamechartNode = ({
         backgroundColor: COLORS.TOOLTIP_BG,
         color: COLORS.TOOLTIP,
       }}
-      ref={tooltipRef}
-    >
+      ref={tooltipRef}>
       {prettyMilliseconds((end - start) / 1000)} {name}
       <div className={styles.DetailsGrid}>
         <div className={styles.DetailsGridLabel}>Script URL:</div> {file}
@@ -162,7 +161,7 @@ const TooltipReactEvent = ({
   event: ReactEvent,
   tooltipRef: Return<typeof useRef>,
 }) => {
-  const { componentName, componentStack, timestamp, type } = event;
+  const {componentName, componentStack, timestamp, type} = event;
 
   let label = null;
   switch (type) {
@@ -186,10 +185,9 @@ const TooltipReactEvent = ({
         backgroundColor: COLORS.TOOLTIP_BG,
         color: COLORS.TOOLTIP,
       }}
-      ref={tooltipRef}
-    >
+      ref={tooltipRef}>
       {componentName && (
-        <span className={styles.ComponentName} style={{ color }}>
+        <span className={styles.ComponentName} style={{color}}>
           {componentName}
         </span>
       )}{' '}
@@ -220,7 +218,7 @@ const TooltipReactMeasure = ({
   measure: ReactMeasure,
   tooltipRef: Return<typeof useRef>,
 }) => {
-  const { batchUID, duration, priority, timestamp, type } = measure;
+  const {batchUID, duration, priority, timestamp, type} = measure;
 
   let label = null;
   switch (type) {
@@ -253,8 +251,7 @@ const TooltipReactMeasure = ({
         backgroundColor: COLORS.TOOLTIP_BG,
         color: COLORS.TOOLTIP,
       }}
-      ref={tooltipRef}
-    >
+      ref={tooltipRef}>
       {prettyMilliseconds(duration)} {label}
       <div className={styles.Divider} />
       <div className={styles.DetailsGrid}>

--- a/src/canvas/canvasUtils.js
+++ b/src/canvas/canvasUtils.js
@@ -7,7 +7,7 @@ import type {
   ReactHoverContextInfo,
   ReactPriority,
 } from '../types';
-import type { PanAndZoomState } from '../util/usePanAndZoom';
+import type {PanAndZoomState} from '../util/usePanAndZoom';
 
 import memoize from 'memoize-one';
 import {
@@ -32,7 +32,7 @@ import usePanAndZoom, {
 export function configureRetinaCanvas(
   canvas: HTMLCanvasElement,
   height: number,
-  width: number
+  width: number,
 ): number {
   const dpr: number = window.devicePixelRatio || 1;
   canvas.width = width * dpr;
@@ -47,30 +47,30 @@ export const getCanvasContext = memoize(
     canvas: HTMLCanvasElement,
     height: number,
     width: number,
-    scaleCanvas: boolean = true
+    scaleCanvas: boolean = true,
   ): CanvasRenderingContext2D => {
-    const context = canvas.getContext('2d', { alpha: false });
+    const context = canvas.getContext('2d', {alpha: false});
     if (scaleCanvas) {
       const dpr = configureRetinaCanvas(canvas, height, width);
       // Scale all drawing operations by the dpr, so you don't have to worry about the difference.
       context.scale(dpr, dpr);
     }
     return context;
-  }
+  },
 );
 
 export function getCanvasMousePos(
   canvas: HTMLCanvasElement,
-  mouseEvent: MouseEvent
+  mouseEvent: MouseEvent,
 ) {
   const rect =
     canvas instanceof HTMLCanvasElement
       ? canvas.getBoundingClientRect()
-      : { left: 0, top: 0 };
+      : {left: 0, top: 0};
   const canvasMouseX = mouseEvent.clientX - rect.left;
   const canvasMouseY = mouseEvent.clientY - rect.top;
 
-  return { canvasMouseX, canvasMouseY };
+  return {canvasMouseX, canvasMouseY};
 }
 
 // Time mark intervals vary based on the current zoom range and the time it represents.
@@ -93,7 +93,7 @@ export const cachedFlamegraphTextWidths = new Map();
 export const trimFlamegraphText = (
   context: CanvasRenderingContext2D,
   text: string,
-  width: number
+  width: number,
 ) => {
   for (let i = text.length - 1; i >= 0; i--) {
     const trimmedText = i === text.length - 1 ? text : text.substr(0, i) + '…';
@@ -116,9 +116,9 @@ export function getHoveredEvent(
   schedulerCanvasHeight: number,
   data: ReactProfilerData | null,
   flamechart: FlamechartData | null,
-  state: PanAndZoomState
+  state: PanAndZoomState,
 ): ReactHoverContextInfo | null {
-  const { canvasMouseX, canvasMouseY, offsetY } = state;
+  const {canvasMouseX, canvasMouseY, offsetY} = state;
 
   if (canvasMouseX < LABEL_FIXED_WIDTH || canvasMouseY < HEADER_HEIGHT_FIXED) {
     return null;
@@ -165,7 +165,7 @@ export function getHoveredEvent(
       if (events !== null) {
         for (let index = events.length - 1; index >= 0; index--) {
           const event = events[index];
-          const { timestamp } = event;
+          const {timestamp} = event;
 
           const eventX = timestampToPosition(timestamp, state);
           const startX = eventX - REACT_EVENT_SIZE / 2;
@@ -185,7 +185,7 @@ export function getHoveredEvent(
         // This will always be the one on "top" (the one the user is hovering over).
         for (let index = measures.length - 1; index >= 0; index--) {
           const measure = measures[index];
-          const { duration, timestamp } = measure;
+          const {duration, timestamp} = measure;
 
           const pointerTime = positionToTimestamp(canvasMouseX, state);
 
@@ -205,7 +205,7 @@ export function getHoveredEvent(
     if (flamechart !== null) {
       const layerIndex = Math.floor(
         (canvasMouseY + offsetY - HEADER_HEIGHT_FIXED - schedulerCanvasHeight) /
-          FLAMECHART_FRAME_HEIGHT
+          FLAMECHART_FRAME_HEIGHT,
       );
       const layer = flamechart.layers[layerIndex];
 
@@ -216,7 +216,7 @@ export function getHoveredEvent(
           const currentIndex = Math.floor((startIndex + stopIndex) / 2);
           const flamechartNode = layer[currentIndex];
 
-          const { end, start } = flamechartNode;
+          const {end, start} = flamechartNode;
 
           const width = durationToWidth((end - start) / 1000, state);
           const x = Math.floor(timestampToPosition(start / 1000, state));
@@ -247,7 +247,7 @@ export function getHoveredEvent(
 const cachedPriorityHeights = new Map();
 export const getPriorityHeight = (
   data: ReactProfilerData,
-  priority: ReactPriority
+  priority: ReactPriority,
 ): number => {
   if (cachedPriorityHeights.has(priority)) {
     // We know the value must be present because we've just checked.

--- a/src/canvas/renderCanvas.js
+++ b/src/canvas/renderCanvas.js
@@ -263,7 +263,7 @@ export const renderCanvas = memoize(
         let baseY = priorityMinY + REACT_GUTTER_SIZE;
 
         if (currentPriority.events.length > 0) {
-          currentPriority.events.forEach((event) => {
+          currentPriority.events.forEach(event => {
             const showHoverHighlight =
               hoveredEvent && hoveredEvent.event === event;
             renderReact({
@@ -296,7 +296,7 @@ export const renderCanvas = memoize(
           baseY += REACT_EVENT_SIZE + REACT_GUTTER_SIZE;
         }
 
-        currentPriority.measures.forEach((measure) => {
+        currentPriority.measures.forEach(measure => {
           const showHoverHighlight =
             hoveredEvent && hoveredEvent.measure === measure;
           const showGroupHighlight =

--- a/src/canvas/renderCanvas.js
+++ b/src/canvas/renderCanvas.js
@@ -5,7 +5,7 @@ import type {
   FlamechartData,
   ReactHoverContextInfo,
 } from '../types';
-import type { PanAndZoomState } from '../util/usePanAndZoom';
+import type {PanAndZoomState} from '../util/usePanAndZoom';
 
 import React from 'react';
 import memoize from 'memoize-one';
@@ -89,8 +89,8 @@ export const renderReact = ({
   showHoverHighlight,
   state,
 }) => {
-  const { timestamp, type } = eventOrMeasure;
-  const { offsetY } = state;
+  const {timestamp, type} = eventOrMeasure;
+  const {offsetY} = state;
 
   let fillStyle = null;
   let hoveredFillStyle = null;
@@ -103,7 +103,7 @@ export const renderReact = ({
     case 'render':
     case 'layout-effects':
     case 'passive-effects':
-      const { depth, duration } = ((eventOrMeasure: any): ReactMeasure);
+      const {depth, duration} = ((eventOrMeasure: any): ReactMeasure);
 
       // We could change the max to 0 and just skip over rendering anything that small,
       // but this has the effect of making the chart look very empty when zoomed out.
@@ -166,13 +166,13 @@ export const renderReact = ({
         Math.floor(x),
         Math.floor(y),
         Math.floor(width),
-        REACT_WORK_SIZE
+        REACT_WORK_SIZE,
       );
       break;
     case 'schedule-render':
     case 'schedule-state-update':
     case 'suspend':
-      const { isCascading } = ((eventOrMeasure: any): ReactEvent);
+      const {isCascading} = ((eventOrMeasure: any): ReactEvent);
 
       x = timestampToPosition(timestamp, state);
       if (x + EVENT_SIZE / 2 < 0 || canvasWidth < x) {
@@ -228,9 +228,9 @@ export const renderCanvas = memoize(
     canvasHeight: number,
     schedulerCanvasHeight: number,
     state: PanAndZoomState,
-    hoveredEvent: ReactHoverContextInfo | null
+    hoveredEvent: ReactHoverContextInfo | null,
   ) => {
-    const { offsetX, offsetY, zoomLevel } = state;
+    const {offsetX, offsetY, zoomLevel} = state;
 
     const context = getCanvasContext(canvas, canvasHeight, canvasWidth, true);
 
@@ -263,7 +263,7 @@ export const renderCanvas = memoize(
         let baseY = priorityMinY + REACT_GUTTER_SIZE;
 
         if (currentPriority.events.length > 0) {
-          currentPriority.events.forEach(event => {
+          currentPriority.events.forEach((event) => {
             const showHoverHighlight =
               hoveredEvent && hoveredEvent.event === event;
             renderReact({
@@ -296,7 +296,7 @@ export const renderCanvas = memoize(
           baseY += REACT_EVENT_SIZE + REACT_GUTTER_SIZE;
         }
 
-        currentPriority.measures.forEach(measure => {
+        currentPriority.measures.forEach((measure) => {
           const showHoverHighlight =
             hoveredEvent && hoveredEvent.measure === measure;
           const showGroupHighlight =
@@ -333,7 +333,7 @@ export const renderCanvas = memoize(
           HEADER_HEIGHT_FIXED +
             schedulerCanvasHeight +
             i * FLAMECHART_FRAME_HEIGHT -
-            offsetY
+            offsetY,
         );
         if (
           y + FLAMECHART_FRAME_HEIGHT < HEADER_HEIGHT_FIXED ||
@@ -343,8 +343,8 @@ export const renderCanvas = memoize(
         }
 
         for (let j = 0; j < nodes.length; j++) {
-          const { end, node, start } = nodes[j];
-          const { name } = node.frame;
+          const {end, node, start} = nodes[j];
+          const {name} = node.frame;
 
           let showHoverHighlight =
             hoveredEvent && hoveredEvent.flamechartNode === nodes[j];
@@ -367,21 +367,21 @@ export const renderCanvas = memoize(
             x,
             y,
             Math.floor(width - REACT_PRIORITY_BORDER_SIZE),
-            Math.floor(FLAMECHART_FRAME_HEIGHT - REACT_PRIORITY_BORDER_SIZE)
+            Math.floor(FLAMECHART_FRAME_HEIGHT - REACT_PRIORITY_BORDER_SIZE),
           );
 
           if (width > FLAMECHART_TEXT_PADDING * 2) {
             const trimmedName = trimFlamegraphText(
               context,
               name,
-              width - FLAMECHART_TEXT_PADDING * 2 + (x < 0 ? x : 0)
+              width - FLAMECHART_TEXT_PADDING * 2 + (x < 0 ? x : 0),
             );
             if (trimmedName !== null) {
               context.fillStyle = COLORS.PRIORITY_LABEL;
               context.fillText(
                 trimmedName,
                 x + FLAMECHART_TEXT_PADDING - (x < 0 ? x : 0),
-                y + FLAMECHART_FRAME_HEIGHT / 2
+                y + FLAMECHART_FRAME_HEIGHT / 2,
               );
             }
           }
@@ -406,7 +406,7 @@ export const renderCanvas = memoize(
         0,
         Math.floor(y),
         Math.floor(LABEL_FIXED_WIDTH),
-        priorityHeight
+        priorityHeight,
       );
 
       context.fillStyle = COLORS.PRIORITY_BORDER;
@@ -414,7 +414,7 @@ export const renderCanvas = memoize(
         0,
         Math.floor(y + priorityHeight),
         canvasWidth,
-        REACT_PRIORITY_BORDER_SIZE
+        REACT_PRIORITY_BORDER_SIZE,
       );
 
       context.fillStyle = COLORS.PRIORITY_BORDER;
@@ -422,7 +422,7 @@ export const renderCanvas = memoize(
         Math.floor(LABEL_FIXED_WIDTH) - REACT_PRIORITY_BORDER_SIZE,
         Math.floor(y),
         REACT_PRIORITY_BORDER_SIZE,
-        priorityHeight
+        priorityHeight,
       );
 
       context.fillStyle = COLORS.PRIORITY_LABEL;
@@ -454,7 +454,7 @@ export const renderCanvas = memoize(
       if (i > 0) {
         const markerTimestamp = positionToTimestamp(
           i + LABEL_FIXED_WIDTH,
-          state
+          state,
         );
         const markerLabel = Math.round(markerTimestamp);
 
@@ -465,7 +465,7 @@ export const renderCanvas = memoize(
           x,
           MARKER_HEIGHT - MARKER_TICK_HEIGHT,
           REACT_PRIORITY_BORDER_SIZE,
-          MARKER_TICK_HEIGHT
+          MARKER_TICK_HEIGHT,
         );
 
         context.fillStyle = COLORS.TIME_MARKER_LABEL;
@@ -475,9 +475,9 @@ export const renderCanvas = memoize(
         context.fillText(
           `${markerLabel}ms`,
           x - MARKER_TEXT_PADDING,
-          MARKER_HEIGHT / 2
+          MARKER_HEIGHT / 2,
         );
       }
     }
-  }
+  },
 );

--- a/src/context/ContextMenu.js
+++ b/src/context/ContextMenu.js
@@ -7,8 +7,8 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import { createPortal } from 'react-dom';
-import { RegistryContext } from './Contexts';
+import {createPortal} from 'react-dom';
+import {RegistryContext} from './Contexts';
 
 import styles from './ContextMenu.css';
 
@@ -49,8 +49,8 @@ type Props = {|
   id: string,
 |};
 
-export default function ContextMenu({ children, id }: Props) {
-  const { hideMenu, registerMenu } = useContext(RegistryContext);
+export default function ContextMenu({children, id}: Props) {
+  const {hideMenu, registerMenu} = useContext(RegistryContext);
 
   const [state, setState] = useState(HIDDEN_STATE);
 
@@ -75,8 +75,8 @@ export default function ContextMenu({ children, id }: Props) {
   }, [bodyAccessorRef, containerRef]);
 
   useEffect(() => {
-    const showMenu = ({ data, pageX, pageY }) => {
-      setState({ data, isVisible: true, pageX, pageY });
+    const showMenu = ({data, pageX, pageY}) => {
+      setState({data, isVisible: true, pageX, pageY});
     };
     const hideMenu = () => setState(HIDDEN_STATE);
     return registerMenu(id, showMenu, hideMenu);
@@ -94,7 +94,7 @@ export default function ContextMenu({ children, id }: Props) {
 
     const hideUnlessContains: MouseEventHandler &
       TouchEventHandler &
-      KeyboardEventHandler = event => {
+      KeyboardEventHandler = (event) => {
       if (!menu.contains(event.target)) {
         hideMenu();
       }
@@ -126,7 +126,7 @@ export default function ContextMenu({ children, id }: Props) {
       <div ref={menuRef} className={styles.ContextMenu}>
         {children(state.data)}
       </div>,
-      containerRef.current
+      containerRef.current,
     );
   }
 }

--- a/src/context/ContextMenu.js
+++ b/src/context/ContextMenu.js
@@ -94,7 +94,7 @@ export default function ContextMenu({children, id}: Props) {
 
     const hideUnlessContains: MouseEventHandler &
       TouchEventHandler &
-      KeyboardEventHandler = (event) => {
+      KeyboardEventHandler = event => {
       if (!menu.contains(event.target)) {
         hideMenu();
       }

--- a/src/context/ContextMenuItem.js
+++ b/src/context/ContextMenuItem.js
@@ -1,7 +1,7 @@
 // @flow
 
-import React, { useContext } from 'react';
-import { RegistryContext } from './Contexts';
+import React, {useContext} from 'react';
+import {RegistryContext} from './Contexts';
 
 import styles from './ContextMenuItem.css';
 
@@ -11,10 +11,10 @@ type Props = {|
   title: string,
 |};
 
-export default function ContextMenuItem({ children, onClick, title }: Props) {
-  const { hideMenu } = useContext(RegistryContext);
+export default function ContextMenuItem({children, onClick, title}: Props) {
+  const {hideMenu} = useContext(RegistryContext);
 
-  const handleClick: MouseEventHandler = event => {
+  const handleClick: MouseEventHandler = (event) => {
     onClick();
     hideMenu();
   };
@@ -23,8 +23,7 @@ export default function ContextMenuItem({ children, onClick, title }: Props) {
     <div
       className={styles.ContextMenuItem}
       onClick={handleClick}
-      onTouchEnd={handleClick}
-    >
+      onTouchEnd={handleClick}>
       {children}
     </div>
   );

--- a/src/context/ContextMenuItem.js
+++ b/src/context/ContextMenuItem.js
@@ -14,7 +14,7 @@ type Props = {|
 export default function ContextMenuItem({children, onClick, title}: Props) {
   const {hideMenu} = useContext(RegistryContext);
 
-  const handleClick: MouseEventHandler = (event) => {
+  const handleClick: MouseEventHandler = event => {
     onClick();
     hideMenu();
   };

--- a/src/context/Contexts.js
+++ b/src/context/Contexts.js
@@ -4,7 +4,7 @@ import {createContext} from 'react';
 
 export type ShowFn = ({|data: Object, pageX: number, pageY: number|}) => void;
 export type HideFn = () => void;
-export type OnChangeFn = (boolean) => void;
+export type OnChangeFn = boolean => void;
 
 const idToShowFnMap = new Map<string, ShowFn>();
 const idToHideFnMap = new Map<string, HideFn>();

--- a/src/context/Contexts.js
+++ b/src/context/Contexts.js
@@ -1,10 +1,10 @@
 // @flow
 
-import { createContext } from 'react';
+import {createContext} from 'react';
 
-export type ShowFn = ({| data: Object, pageX: number, pageY: number |}) => void;
+export type ShowFn = ({|data: Object, pageX: number, pageY: number|}) => void;
 export type HideFn = () => void;
-export type OnChangeFn = boolean => void;
+export type OnChangeFn = (boolean) => void;
 
 const idToShowFnMap = new Map<string, ShowFn>();
 const idToHideFnMap = new Map<string, HideFn>();
@@ -41,7 +41,7 @@ function showMenu({
   const showFn = idToShowFnMap.get(id);
   if (typeof showFn === 'function') {
     currentHideFn = idToHideFnMap.get(id);
-    showFn({ data, pageX, pageY });
+    showFn({data, pageX, pageY});
 
     if (typeof onChange === 'function') {
       currentOnChange = onChange;

--- a/src/context/index.js
+++ b/src/context/index.js
@@ -1,8 +1,8 @@
 // @flow
 
-import { RegistryContext } from './Contexts';
+import {RegistryContext} from './Contexts';
 import ContextMenu from './ContextMenu';
 import ContextMenuItem from './ContextMenuItem';
 import useContextMenu from './useContextMenu';
 
-export { RegistryContext, ContextMenu, ContextMenuItem, useContextMenu };
+export {RegistryContext, ContextMenu, ContextMenuItem, useContextMenu};

--- a/src/context/useContextMenu.js
+++ b/src/context/useContextMenu.js
@@ -22,7 +22,7 @@ export default function useContextMenu<T>({
 
   useEffect(() => {
     if (ref.current !== null) {
-      const handleContextMenu: MouseEventHandler = (event) => {
+      const handleContextMenu: MouseEventHandler = event => {
         event.preventDefault();
         event.stopPropagation();
 

--- a/src/context/useContextMenu.js
+++ b/src/context/useContextMenu.js
@@ -1,11 +1,11 @@
 // @flow
 
-import { useContext, useEffect, useRef } from 'react';
-import { RegistryContext } from './Contexts';
+import {useContext, useEffect, useRef} from 'react';
+import {RegistryContext} from './Contexts';
 
-import type { ElementRef } from 'react';
-import type { OnChangeFn } from './Contexts';
-import type { Return } from '../types';
+import type {ElementRef} from 'react';
+import type {OnChangeFn} from './Contexts';
+import type {Return} from '../types';
 
 export default function useContextMenu<T>({
   data,
@@ -18,11 +18,11 @@ export default function useContextMenu<T>({
   onChange: OnChangeFn,
   ref: Return<typeof useRef>,
 |}) {
-  const { showMenu } = useContext(RegistryContext);
+  const {showMenu} = useContext(RegistryContext);
 
   useEffect(() => {
     if (ref.current !== null) {
-      const handleContextMenu: MouseEventHandler = event => {
+      const handleContextMenu: MouseEventHandler = (event) => {
         event.preventDefault();
         event.stopPropagation();
 
@@ -31,7 +31,7 @@ export default function useContextMenu<T>({
         const pageY: number =
           event.pageY || (event.touches && event.touches[0].pageY);
 
-        showMenu({ data, id, onChange, pageX, pageY });
+        showMenu({data, id, onChange, pageX, pageY});
       };
 
       const trigger = ref.current;

--- a/src/graveyard/SelectedEvent.js
+++ b/src/graveyard/SelectedEvent.js
@@ -1,12 +1,12 @@
 import React from 'react';
 import styles from './SelectedEvent.module.css';
 
-export default function SelectedEvent({ selectedEvent, width }) {
+export default function SelectedEvent({selectedEvent, width}) {
   if (selectedEvent == null) {
     return null;
   }
 
-  const { componentStack, duration, timestamp, type } = selectedEvent;
+  const {componentStack, duration, timestamp, type} = selectedEvent;
 
   let label = null;
   switch (type) {
@@ -36,7 +36,7 @@ export default function SelectedEvent({ selectedEvent, width }) {
   }
 
   return (
-    <div className={styles.SelectedEvent} style={{ width }}>
+    <div className={styles.SelectedEvent} style={{width}}>
       {label} {duration !== undefined ? `for ${duration}ms` : ''} at {timestamp}
       ms
       {componentStack && (

--- a/src/graveyard/contexts.js
+++ b/src/graveyard/contexts.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { createContext } from 'react';
+import {createContext} from 'react';
 
 export const PriorityContext = createContext(null);
 export const TimeRangeContext = createContext([0, 0]);

--- a/src/graveyard/useDebounce.js
+++ b/src/graveyard/useDebounce.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { useDebugValue, useEffect, useState } from 'react';
+import {useDebugValue, useEffect, useState} from 'react';
 
 // Below copied from https://usehooks.com/
 export default function useDebounce<T>(value: T, delay: number): T {
@@ -24,7 +24,7 @@ export default function useDebounce<T>(value: T, delay: number): T {
         clearTimeout(handler);
       };
     },
-    [value, delay] // Only re-call effect if value or delay changes
+    [value, delay], // Only re-call effect if value or delay changes
   );
 
   return debouncedValue;

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
-import { createElement } from 'react';
-import { render } from 'react-dom';
+import {createElement} from 'react';
+import {render} from 'react-dom';
 import App from './App';
 import './index.css';
 

--- a/src/serviceWorker.js
+++ b/src/serviceWorker.js
@@ -16,8 +16,8 @@ const isLocalhost = Boolean(
     window.location.hostname === '[::1]' ||
     // 127.0.0.1/8 is considered localhost for IPv4.
     window.location.hostname.match(
-      /^127(?:\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$/
-    )
+      /^127(?:\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$/,
+    ),
 );
 
 export function register(config) {
@@ -43,7 +43,7 @@ export function register(config) {
         navigator.serviceWorker.ready.then(() => {
           console.log(
             'This web app is being served cache-first by a service ' +
-              'worker. To learn more, visit https://bit.ly/CRA-PWA'
+              'worker. To learn more, visit https://bit.ly/CRA-PWA',
           );
         });
       } else {
@@ -57,7 +57,7 @@ export function register(config) {
 function registerValidSW(swUrl, config) {
   navigator.serviceWorker
     .register(swUrl)
-    .then(registration => {
+    .then((registration) => {
       registration.onupdatefound = () => {
         const installingWorker = registration.installing;
         if (installingWorker == null) {
@@ -71,7 +71,7 @@ function registerValidSW(swUrl, config) {
               // content until all client tabs are closed.
               console.log(
                 'New content is available and will be used when all ' +
-                  'tabs for this page are closed. See https://bit.ly/CRA-PWA.'
+                  'tabs for this page are closed. See https://bit.ly/CRA-PWA.',
               );
 
               // Execute callback
@@ -93,7 +93,7 @@ function registerValidSW(swUrl, config) {
         };
       };
     })
-    .catch(error => {
+    .catch((error) => {
       console.error('Error during service worker registration:', error);
     });
 }
@@ -101,7 +101,7 @@ function registerValidSW(swUrl, config) {
 function checkValidServiceWorker(swUrl, config) {
   // Check if the service worker can be found. If it can't reload the page.
   fetch(swUrl)
-    .then(response => {
+    .then((response) => {
       // Ensure service worker exists, and that we really are getting a JS file.
       const contentType = response.headers.get('content-type');
       if (
@@ -109,7 +109,7 @@ function checkValidServiceWorker(swUrl, config) {
         (contentType != null && contentType.indexOf('javascript') === -1)
       ) {
         // No service worker found. Probably a different app. Reload the page.
-        navigator.serviceWorker.ready.then(registration => {
+        navigator.serviceWorker.ready.then((registration) => {
           registration.unregister().then(() => {
             window.location.reload();
           });
@@ -121,14 +121,14 @@ function checkValidServiceWorker(swUrl, config) {
     })
     .catch(() => {
       console.log(
-        'No internet connection found. App is running in offline mode.'
+        'No internet connection found. App is running in offline mode.',
       );
     });
 }
 
 export function unregister() {
   if ('serviceWorker' in navigator) {
-    navigator.serviceWorker.ready.then(registration => {
+    navigator.serviceWorker.ready.then((registration) => {
       registration.unregister();
     });
   }

--- a/src/serviceWorker.js
+++ b/src/serviceWorker.js
@@ -57,7 +57,7 @@ export function register(config) {
 function registerValidSW(swUrl, config) {
   navigator.serviceWorker
     .register(swUrl)
-    .then((registration) => {
+    .then(registration => {
       registration.onupdatefound = () => {
         const installingWorker = registration.installing;
         if (installingWorker == null) {
@@ -93,7 +93,7 @@ function registerValidSW(swUrl, config) {
         };
       };
     })
-    .catch((error) => {
+    .catch(error => {
       console.error('Error during service worker registration:', error);
     });
 }
@@ -101,7 +101,7 @@ function registerValidSW(swUrl, config) {
 function checkValidServiceWorker(swUrl, config) {
   // Check if the service worker can be found. If it can't reload the page.
   fetch(swUrl)
-    .then((response) => {
+    .then(response => {
       // Ensure service worker exists, and that we really are getting a JS file.
       const contentType = response.headers.get('content-type');
       if (
@@ -109,7 +109,7 @@ function checkValidServiceWorker(swUrl, config) {
         (contentType != null && contentType.indexOf('javascript') === -1)
       ) {
         // No service worker found. Probably a different app. Reload the page.
-        navigator.serviceWorker.ready.then((registration) => {
+        navigator.serviceWorker.ready.then(registration => {
           registration.unregister().then(() => {
             window.location.reload();
           });
@@ -128,7 +128,7 @@ function checkValidServiceWorker(swUrl, config) {
 
 export function unregister() {
   if ('serviceWorker' in navigator) {
-    navigator.serviceWorker.ready.then((registration) => {
+    navigator.serviceWorker.ready.then(registration => {
       registration.unregister();
     });
   }

--- a/src/types.js
+++ b/src/types.js
@@ -1,6 +1,6 @@
 // @flow
 
-import type { Flamechart, FlamechartFrame } from './speedscope/lib/flamechart';
+import type {Flamechart, FlamechartFrame} from './speedscope/lib/flamechart';
 
 // Type utilities
 

--- a/src/util/getBatchRange.js
+++ b/src/util/getBatchRange.js
@@ -15,9 +15,9 @@ import type {
 function unmemoizedGetBatchRange(
   batchUID: BatchUID,
   priority: ReactPriority,
-  data: ReactProfilerData
+  data: ReactProfilerData,
 ): [Milliseconds, Milliseconds] {
-  const { measures } = data[priority];
+  const {measures} = data[priority];
 
   let startTime = 0;
   let stopTime = Infinity;

--- a/src/util/preprocessData.js
+++ b/src/util/preprocessData.js
@@ -176,7 +176,7 @@ export default function reactProfilerProcessor(
     });
   };
 
-  const throwIfIncomplete = (type) => {
+  const throwIfIncomplete = type => {
     if (!currentMetadata) {
       return;
     }
@@ -316,7 +316,7 @@ export default function reactProfilerProcessor(
     }
   });
 
-  ['unscheduled', 'high', 'normal', 'low'].forEach((priority) => {
+  ['unscheduled', 'high', 'normal', 'low'].forEach(priority => {
     const {events, measures} = reactProfilerData[priority];
     if (events.length > 0) {
       const {timestamp} = (events[events.length - 1]: ReactEvent);

--- a/src/util/preprocessData.js
+++ b/src/util/preprocessData.js
@@ -1,6 +1,6 @@
 // @flow
 
-import type { TimelineEvent } from './speedscope/import/chrome';
+import type {TimelineEvent} from './speedscope/import/chrome';
 
 import type {
   Milliseconds,
@@ -30,7 +30,7 @@ type Metadata = {|
 |};
 
 export default function reactProfilerProcessor(
-  rawData: TimelineEvent[]
+  rawData: TimelineEvent[],
 ): ReactProfilerData {
   const reactProfilerData = {
     startTime: rawData[0].ts,
@@ -62,7 +62,7 @@ export default function reactProfilerProcessor(
   let currentProfilerDataGroup: ReactProfilerDataPriority | null = null;
   let uidCounter = 0;
 
-  const metadata: {| [priority: ReactPriority]: Metadata |} = {
+  const metadata: {|[priority: ReactPriority]: Metadata|} = {
     high: {
       batchUID: 0,
       nextRenderShouldGenerateNewBatchID: true,
@@ -89,9 +89,9 @@ export default function reactProfilerProcessor(
     if (!currentMetadata) {
       return null;
     }
-    const { stack } = currentMetadata;
+    const {stack} = currentMetadata;
     if (stack.length > 0) {
-      const { type } = stack[stack.length - 1];
+      const {type} = stack[stack.length - 1];
       return type;
     }
     return null;
@@ -101,9 +101,9 @@ export default function reactProfilerProcessor(
     if (!currentMetadata) {
       return 0;
     }
-    const { stack } = currentMetadata;
+    const {stack} = currentMetadata;
     if (stack.length > 0) {
-      const { depth, type } = (stack[stack.length - 1]: StackElement);
+      const {depth, type} = (stack[stack.length - 1]: StackElement);
       return type === 'render-idle' ? depth : depth + 1;
     }
     return 0;
@@ -111,30 +111,30 @@ export default function reactProfilerProcessor(
 
   const markWorkCompleted = (
     type: ReactMeasureType,
-    stopTime: Milliseconds
+    stopTime: Milliseconds,
   ) => {
     if (!currentMetadata) {
       return;
     }
-    const { stack } = currentMetadata;
+    const {stack} = currentMetadata;
     if (stack.length === 0) {
       console.error(
-        `Unexpected type "${type}" completed while stack is empty.`
+        `Unexpected type "${type}" completed while stack is empty.`,
       );
     } else {
       const last = stack[stack.length - 1];
       if (last.type !== type) {
         console.error(
-          `Unexpected type "${type}" completed before "${last.type}" completed.`
+          `Unexpected type "${type}" completed before "${last.type}" completed.`,
         );
       } else {
-        const { index, startTime } = stack.pop();
+        const {index, startTime} = stack.pop();
 
         if (currentProfilerDataGroup) {
           const measure = currentProfilerDataGroup.measures[index];
           if (!measure) {
             console.error(
-              `Could not find matching measure for type "${type}".`
+              `Could not find matching measure for type "${type}".`,
             );
           } else {
             // $FlowFixMe This property should not be writable outside of this function.
@@ -149,14 +149,14 @@ export default function reactProfilerProcessor(
     if (!currentMetadata || !currentProfilerDataGroup) {
       return;
     }
-    const { batchUID, stack } = currentMetadata;
+    const {batchUID, stack} = currentMetadata;
 
     const index = currentProfilerDataGroup.measures.length;
     const depth = getDepth();
 
     currentProfilerDataGroup.maxNestedMeasures = Math.max(
       currentProfilerDataGroup.maxNestedMeasures,
-      depth + 1
+      depth + 1,
     );
 
     stack.push({
@@ -176,17 +176,17 @@ export default function reactProfilerProcessor(
     });
   };
 
-  const throwIfIncomplete = type => {
+  const throwIfIncomplete = (type) => {
     if (!currentMetadata) {
       return;
     }
-    const { stack } = currentMetadata;
+    const {stack} = currentMetadata;
     const lastIndex = stack.length - 1;
     if (lastIndex >= 0) {
       const last = stack[lastIndex];
       if (last.stopTime === undefined && last.type === type) {
         throw new Error(
-          `Unexpected type "${type}" started before "${last.type}" completed.`
+          `Unexpected type "${type}" started before "${last.type}" completed.`,
         );
       }
     }
@@ -195,7 +195,7 @@ export default function reactProfilerProcessor(
   for (let i = 0; i < rawData.length; i++) {
     const currentEvent = rawData[i];
 
-    const { cat, name, ts } = currentEvent;
+    const {cat, name, ts} = currentEvent;
 
     if (cat !== 'blink.user_timing' || !name.startsWith('--')) {
       continue;
@@ -217,7 +217,7 @@ export default function reactProfilerProcessor(
     if (name.startsWith('--scheduler-start-')) {
       if (currentPriority !== 'unscheduled') {
         console.error(
-          `Unexpected scheduler start: "${name}" with current priority: "${currentPriority}"`
+          `Unexpected scheduler start: "${name}" with current priority: "${currentPriority}"`,
         );
         continue; // TODO Should we throw? Will this corrupt our data?
       }
@@ -229,7 +229,7 @@ export default function reactProfilerProcessor(
         currentPriority !== name.substr(17)
       ) {
         console.error(
-          `Unexpected scheduler stop: "${name}" with current priority: "${currentPriority}"`
+          `Unexpected scheduler stop: "${name}" with current priority: "${currentPriority}"`,
         );
         continue; // TODO Should we throw? Will this corrupt our data?
       }
@@ -284,7 +284,7 @@ export default function reactProfilerProcessor(
     } else if (name.startsWith('--schedule-state-update-')) {
       const [componentName, componentStack] = name.substr(24).split('-');
       const isCascading = !!currentMetadata.stack.find(
-        ({ type }) => type === 'commit'
+        ({type}) => type === 'commit',
       );
       currentProfilerDataGroup.events.push({
         type: 'schedule-state-update',
@@ -307,29 +307,29 @@ export default function reactProfilerProcessor(
   }
 
   Object.entries(metadata).forEach(([priority, metadata]) => {
-    const { stack } = ((metadata: any): Metadata);
+    const {stack} = ((metadata: any): Metadata);
     if (stack.length > 0) {
       console.error(
         `Incomplete events or measures for priority ${priority}`,
-        stack
+        stack,
       );
     }
   });
 
-  ['unscheduled', 'high', 'normal', 'low'].forEach(priority => {
-    const { events, measures } = reactProfilerData[priority];
+  ['unscheduled', 'high', 'normal', 'low'].forEach((priority) => {
+    const {events, measures} = reactProfilerData[priority];
     if (events.length > 0) {
-      const { timestamp } = (events[events.length - 1]: ReactEvent);
+      const {timestamp} = (events[events.length - 1]: ReactEvent);
       reactProfilerData.duration = Math.max(
         reactProfilerData.duration,
-        timestamp
+        timestamp,
       );
     }
     if (measures.length > 0) {
-      const { duration, timestamp } = measures[measures.length - 1];
+      const {duration, timestamp} = measures[measures.length - 1];
       reactProfilerData.duration = Math.max(
         reactProfilerData.duration,
-        timestamp + duration
+        timestamp + duration,
       );
     }
   });

--- a/src/util/preprocessFlamechart.js
+++ b/src/util/preprocessFlamechart.js
@@ -1,13 +1,13 @@
 // @flow
 
-import { importFromChromeTimeline } from '../speedscope/import/chrome';
-import { Flamechart } from '../speedscope/lib/flamechart';
+import {importFromChromeTimeline} from '../speedscope/import/chrome';
+import {Flamechart} from '../speedscope/lib/flamechart';
 
-import type { TimelineEvent } from './speedscope/import/chrome';
-import type { FlamechartData } from './types';
+import type {TimelineEvent} from './speedscope/import/chrome';
+import type {FlamechartData} from './types';
 
 export default function preprocessFlamechart(
-  rawData: TimelineEvent[]
+  rawData: TimelineEvent[],
 ): FlamechartData {
   const parsedData = importFromChromeTimeline(rawData, 'react-devtools');
   const profile = parsedData.profiles[0]; // TODO Choose the main CPU thread only

--- a/src/util/useInteractiveEvents.js
+++ b/src/util/useInteractiveEvents.js
@@ -1,11 +1,11 @@
 // @flow
 
-import { useEffect, useRef, useState } from 'react';
-import { durationToWidth, timestampToPosition } from './usePanAndZoom';
-import { EVENT_SIZE } from '../constants';
+import {useEffect, useRef, useState} from 'react';
+import {durationToWidth, timestampToPosition} from './usePanAndZoom';
+import {EVENT_SIZE} from '../constants';
 
 function doesEventIntersectPosition(position, state, event) {
-  const { duration, timestamp } = event;
+  const {duration, timestamp} = event;
 
   // Although it would be intuitive to search by time,
   // that can result in a confusing user experience for events of 0ms duration-
@@ -65,7 +65,7 @@ export default function useInteractiveEvents({
 
   useEffect(() => {
     const onClick = () => {
-      const { hoveredEvent, selectedEvent } = lastResultRef.current;
+      const {hoveredEvent, selectedEvent} = lastResultRef.current;
       setSelectedEvent(hoveredEvent === selectedEvent ? null : hoveredEvent);
     };
     const canvas = canvasRef.current;

--- a/src/util/usePanAndZoom.js
+++ b/src/util/usePanAndZoom.js
@@ -1,7 +1,7 @@
 // @flow
 
-import { useEffect, useReducer } from 'react';
-import { getCanvasMousePos } from '../canvas/canvasUtils';
+import {useEffect, useReducer} from 'react';
+import {getCanvasMousePos} from '../canvas/canvasUtils';
 import {
   BAR_HORIZONTAL_SPACING,
   MAX_ZOOM_LEVEL,
@@ -58,7 +58,7 @@ export function timestampToPosition(timestamp: number, state: PanAndZoomState) {
 export function durationToWidth(duration: number, state: PanAndZoomState) {
   return Math.max(
     duration * state.zoomLevel - BAR_HORIZONTAL_SPACING,
-    MIN_BAR_WIDTH
+    MIN_BAR_WIDTH,
   );
 }
 
@@ -116,11 +116,11 @@ function reducer(
     | MouseMoveAction
     | MouseUpAction
     | WheelAction
-    | ZoomToAction
+    | ZoomToAction,
 ): PanAndZoomState {
   switch (action.type) {
     case 'initialize': {
-      const { payload } = action;
+      const {payload} = action;
       return ({
         ...state,
         canvasHeight: payload.canvasHeight,
@@ -142,10 +142,10 @@ function reducer(
       };
     }
     case 'mouse-move': {
-      const { payload } = action;
-      const { canvasMouseX, canvasMouseY } = getCanvasMousePos(
+      const {payload} = action;
+      const {canvasMouseX, canvasMouseY} = getCanvasMousePos(
         payload.canvas,
-        payload.event
+        payload.event,
       );
 
       if (state.isDragging) {
@@ -156,12 +156,12 @@ function reducer(
           offsetX: clamp(
             0,
             getMaxOffsetX(state),
-            state.offsetX - payload.event.movementX
+            state.offsetX - payload.event.movementX,
           ),
           offsetY: clamp(
             0,
             getMaxOffsetY(state),
-            state.offsetY + payload.event.movementY
+            state.offsetY + payload.event.movementY,
           ),
         };
       } else {
@@ -179,9 +179,9 @@ function reducer(
       };
     }
     case 'wheel': {
-      const { payload } = action;
-      const { canvas, event } = payload;
-      const { deltaX, deltaY } = event;
+      const {payload} = action;
+      const {canvas, event} = payload;
+      const {deltaX, deltaY} = event;
       const {
         minZoomLevel,
         offsetX,
@@ -204,14 +204,14 @@ function reducer(
       } else {
         if (event.shiftKey || event.ctrlKey || event.metaKey) {
           if (absDeltaY > ZOOM_WHEEL_DELTA_THRESHOLD) {
-            const { canvasMouseX } = getCanvasMousePos(canvas, event);
+            const {canvasMouseX} = getCanvasMousePos(canvas, event);
 
             const nextState = {
               ...state,
               zoomLevel: clamp(
                 minZoomLevel,
                 MAX_ZOOM_LEVEL,
-                zoomLevel * (1 + 0.005 * -deltaY)
+                zoomLevel * (1 + 0.005 * -deltaY),
               ),
             };
 
@@ -219,17 +219,17 @@ function reducer(
             // and adjust the offset so that point stays centered after zooming.
             const timestampAtCurrentZoomLevel = positionToTimestamp(
               canvasMouseX,
-              state
+              state,
             );
             const positionAtNewZoom = timestampToPosition(
               timestampAtCurrentZoomLevel,
-              nextState
+              nextState,
             );
 
             nextState.offsetX = clamp(
               0,
               getMaxOffsetX(nextState),
-              offsetX + positionAtNewZoom - canvasMouseX
+              offsetX + positionAtNewZoom - canvasMouseX,
             );
 
             if (nextState.zoomLevel !== zoomLevel) {
@@ -248,9 +248,9 @@ function reducer(
       break;
     }
     case 'zoom-to': {
-      const { payload } = action;
-      const { startTime, stopTime } = payload;
-      const { canvasWidth, fixedColumnWidth } = state;
+      const {payload} = action;
+      const {startTime, stopTime} = payload;
+      const {canvasWidth, fixedColumnWidth} = state;
 
       const availableWidth = canvasWidth - fixedColumnWidth;
       const newZoomLevel = availableWidth / (stopTime - startTime);
@@ -276,7 +276,7 @@ function clamp(min: number, max: number, value: number): number {
 }
 
 type Props = {|
-  canvasRef: {| current: HTMLCanvasElement | null |},
+  canvasRef: {|current: HTMLCanvasElement | null|},
   canvasHeight: number,
   canvasWidth: number,
   fixedColumnWidth: number,
@@ -314,7 +314,7 @@ export default function usePanAndZoom({
     const initialZoomLevel = clamp(
       MIN_ZOOM_LEVEL,
       MAX_ZOOM_LEVEL,
-      (width - fixedColumnWidth) / unscaledContentWidth
+      (width - fixedColumnWidth) / unscaledContentWidth,
     );
 
     dispatch({
@@ -347,11 +347,11 @@ export default function usePanAndZoom({
       return;
     }
 
-    const onCanvasMouseDown: MouseEventHandler = event => {
-      dispatch({ type: 'mouse-down' });
+    const onCanvasMouseDown: MouseEventHandler = (event) => {
+      dispatch({type: 'mouse-down'});
     };
 
-    const onCanvasMouseMove: MouseEventHandler = event => {
+    const onCanvasMouseMove: MouseEventHandler = (event) => {
       dispatch({
         type: 'mouse-move',
         payload: {
@@ -361,11 +361,11 @@ export default function usePanAndZoom({
       });
     };
 
-    const onDocumentMouseUp: MouseEventHandler = event => {
-      dispatch({ type: 'mouse-up' });
+    const onDocumentMouseUp: MouseEventHandler = (event) => {
+      dispatch({type: 'mouse-up'});
     };
 
-    const onCanvasWheel: WheelEventHandler = event => {
+    const onCanvasWheel: WheelEventHandler = (event) => {
       event.preventDefault();
       event.stopPropagation();
 

--- a/src/util/usePanAndZoom.js
+++ b/src/util/usePanAndZoom.js
@@ -347,11 +347,11 @@ export default function usePanAndZoom({
       return;
     }
 
-    const onCanvasMouseDown: MouseEventHandler = (event) => {
+    const onCanvasMouseDown: MouseEventHandler = event => {
       dispatch({type: 'mouse-down'});
     };
 
-    const onCanvasMouseMove: MouseEventHandler = (event) => {
+    const onCanvasMouseMove: MouseEventHandler = event => {
       dispatch({
         type: 'mouse-move',
         payload: {
@@ -361,11 +361,11 @@ export default function usePanAndZoom({
       });
     };
 
-    const onDocumentMouseUp: MouseEventHandler = (event) => {
+    const onDocumentMouseUp: MouseEventHandler = event => {
       dispatch({type: 'mouse-up'});
     };
 
-    const onCanvasWheel: WheelEventHandler = (event) => {
+    const onCanvasWheel: WheelEventHandler = event => {
       event.preventDefault();
       event.stopPropagation();
 

--- a/src/util/useSmartTooltip.js
+++ b/src/util/useSmartTooltip.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { useLayoutEffect, useRef } from 'react';
+import {useLayoutEffect, useRef} from 'react';
 
 const TOOLTIP_OFFSET = 4;
 
@@ -26,9 +26,9 @@ export default function useSmartTooltip({
         // mouse cursor or finally aligned with the window's top edge.
         if (mouseY - TOOLTIP_OFFSET - element.offsetHeight > 0) {
           // We position the tooltip above the mouse cursor if it fits there.
-          element.style.top = `${mouseY -
-            element.offsetHeight -
-            TOOLTIP_OFFSET}px`;
+          element.style.top = `${
+            mouseY - element.offsetHeight - TOOLTIP_OFFSET
+          }px`;
         } else {
           // Otherwise we align the tooltip with the window's top edge.
           element.style.top = '0px';
@@ -46,9 +46,9 @@ export default function useSmartTooltip({
         if (mouseX - TOOLTIP_OFFSET - element.offsetWidth > 0) {
           // We position the tooltip at the left of the mouse cursor if it fits
           // there.
-          element.style.left = `${mouseX -
-            element.offsetWidth -
-            TOOLTIP_OFFSET}px`;
+          element.style.left = `${
+            mouseX - element.offsetWidth - TOOLTIP_OFFSET
+          }px`;
         } else {
           // Otherwise, align the tooltip with the window's left edge.
           element.style.left = '0px';

--- a/src/util/useSmartTooltip.js
+++ b/src/util/useSmartTooltip.js
@@ -26,9 +26,9 @@ export default function useSmartTooltip({
         // mouse cursor or finally aligned with the window's top edge.
         if (mouseY - TOOLTIP_OFFSET - element.offsetHeight > 0) {
           // We position the tooltip above the mouse cursor if it fits there.
-          element.style.top = `${
-            mouseY - element.offsetHeight - TOOLTIP_OFFSET
-          }px`;
+          element.style.top = `${mouseY -
+            element.offsetHeight -
+            TOOLTIP_OFFSET}px`;
         } else {
           // Otherwise we align the tooltip with the window's top edge.
           element.style.top = '0px';
@@ -46,9 +46,9 @@ export default function useSmartTooltip({
         if (mouseX - TOOLTIP_OFFSET - element.offsetWidth > 0) {
           // We position the tooltip at the left of the mouse cursor if it fits
           // there.
-          element.style.left = `${
-            mouseX - element.offsetWidth - TOOLTIP_OFFSET
-          }px`;
+          element.style.left = `${mouseX -
+            element.offsetWidth -
+            TOOLTIP_OFFSET}px`;
         } else {
           // Otherwise, align the tooltip with the window's left edge.
           element.style.left = '0px';

--- a/yarn.lock
+++ b/yarn.lock
@@ -7587,10 +7587,10 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
-prettier@^2.0.5:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.0.5.tgz#d6d56282455243f2f92cc1716692c08aa31522d4"
-  integrity sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==
+prettier@1.19.1:
+  version "1.19.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
+  integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
 
 pretty-format@^25.2.1, pretty-format@^25.5.0:
   version "25.5.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7587,10 +7587,10 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
-prettier@^1.19.1:
-  version "1.19.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
-  integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
+prettier@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.0.5.tgz#d6d56282455243f2f92cc1716692c08aa31522d4"
+  integrity sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==
 
 pretty-format@^25.2.1, pretty-format@^25.5.0:
   version "25.5.0"


### PR DESCRIPTION
1. Froze Prettier version at v1.19.1 (same version that React is using)
1. Copy React's prettier configs
1. Remove Prettier config line that causes Prettier to use the Babel parser - this breaks CSS and JSON file parsing
1. Ran `yarn prettier` to reformat all files.