### PR TITLE
Break App.js into CanvasPage and ImportPage

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -5,13 +5,3 @@
   left: 0.5rem;
   right: 0.5rem;
 }
-
-.Canvas {
-}
-
-.HighlightContainer {
-  pointer-events: none;
-  position: absolute;
-  top: 0;
-  overflow: hidden;
-}

--- a/src/App.js
+++ b/src/App.js
@@ -1,62 +1,45 @@
 // @flow
 
-import type {TimelineEvent} from './speedscope/import/chrome';
 import type {FlamechartData, ReactProfilerData} from './types';
 
-import React, {useEffect, useState} from 'react';
-import {unstable_batchedUpdates} from 'react-dom';
+import React, {useState, useCallback} from 'react';
 import CanvasPage from './CanvasPage';
 
-import {REACT_PRIORITIES} from './canvas/constants';
 import {getPriorityHeight} from './canvas/canvasUtils';
-import preprocessData from './util/preprocessData';
-import preprocessFlamechart from './util/preprocessFlamechart';
-
-// TODO: Add import button but keep a static path until canvas layout is ready
-import JSON_PATH from 'url:../static/small-devtools.json';
+import ImportPage from './ImportPage';
+import {REACT_PRIORITIES} from './canvas/constants';
 
 export default function App() {
-  const [data, setData] = useState<ReactProfilerData | null>(null);
+  const [profilerData, setProfilerData] = useState<ReactProfilerData | null>(
+    null,
+  );
   const [flamechart, setFlamechart] = useState<FlamechartData | null>(null);
   const [schedulerCanvasHeight, setSchedulerCanvasHeight] = useState<number>(0);
 
-  useEffect(() => {
-    fetch(JSON_PATH)
-      .then(res => res.json())
-      .then((events: TimelineEvent[]) => {
-        // Filter null entries and sort by timestamp.
-        // I would not expect to have to do either of this,
-        // but some of the data being passed in requires it.
-        events = events.filter(Boolean).sort((a, b) => (a.ts > b.ts ? 1 : -1));
+  const handleDataImported = useCallback(
+    (
+      importedProfilerData: ReactProfilerData,
+      importedFlamechart: FlamechartData,
+    ) => {
+      setSchedulerCanvasHeight(
+        REACT_PRIORITIES.reduce((height, priority) => {
+          return height + getPriorityHeight(importedProfilerData, priority);
+        }, 0),
+      );
+      setProfilerData(importedProfilerData);
+      setFlamechart(importedFlamechart);
+    },
+  );
 
-        if (events.length > 0) {
-          unstable_batchedUpdates(() => {
-            const processedData = preprocessData(events);
-            setData(processedData);
-
-            setFlamechart(preprocessFlamechart(events));
-
-            let height = 0;
-
-            REACT_PRIORITIES.forEach(priority => {
-              height += getPriorityHeight(processedData, priority);
-            });
-
-            setSchedulerCanvasHeight(height);
-          });
-        }
-      });
-  }, []);
-
-  if (data && flamechart) {
+  if (profilerData && flamechart) {
     return (
       <CanvasPage
-        profilerData={data}
+        profilerData={profilerData}
         flamechart={flamechart}
         schedulerCanvasHeight={schedulerCanvasHeight}
       />
     );
   } else {
-    return <div>Loading</div>;
+    return <ImportPage onDataImported={handleDataImported} />;
   }
 }

--- a/src/App.js
+++ b/src/App.js
@@ -3,11 +3,12 @@
 import type {FlamechartData, ReactProfilerData} from './types';
 
 import React, {useState, useCallback} from 'react';
-import CanvasPage from './CanvasPage';
+import {unstable_batchedUpdates} from 'react-dom';
 
 import {getPriorityHeight} from './canvas/canvasUtils';
-import ImportPage from './ImportPage';
 import {REACT_PRIORITIES} from './canvas/constants';
+import ImportPage from './ImportPage';
+import CanvasPage from './CanvasPage';
 
 export default function App() {
   const [profilerData, setProfilerData] = useState<ReactProfilerData | null>(
@@ -21,13 +22,15 @@ export default function App() {
       importedProfilerData: ReactProfilerData,
       importedFlamechart: FlamechartData,
     ) => {
-      setSchedulerCanvasHeight(
-        REACT_PRIORITIES.reduce((height, priority) => {
-          return height + getPriorityHeight(importedProfilerData, priority);
-        }, 0),
-      );
-      setProfilerData(importedProfilerData);
-      setFlamechart(importedFlamechart);
+      unstable_batchedUpdates(() => {
+        setSchedulerCanvasHeight(
+          REACT_PRIORITIES.reduce((height, priority) => {
+            return height + getPriorityHeight(importedProfilerData, priority);
+          }, 0),
+        );
+        setProfilerData(importedProfilerData);
+        setFlamechart(importedFlamechart);
+      });
     },
   );
 

--- a/src/App.js
+++ b/src/App.js
@@ -1,59 +1,21 @@
 // @flow
 
 import type {TimelineEvent} from './speedscope/import/chrome';
-import type {PanAndZoomState} from './util/usePanAndZoom';
+import type {FlamechartData, ReactProfilerData} from './types';
 
-import {copy} from 'clipboard-js';
-import React, {
-  Fragment,
-  useEffect,
-  useLayoutEffect,
-  useRef,
-  useState,
-} from 'react';
+import React, {useEffect, useState} from 'react';
 import {unstable_batchedUpdates} from 'react-dom';
-import usePanAndZoom from './util/usePanAndZoom';
+import CanvasPage from './CanvasPage';
 
-import {getHoveredEvent, getPriorityHeight} from './canvas/canvasUtils';
-import {renderCanvas} from './canvas/renderCanvas';
-
-import prettyMilliseconds from 'pretty-ms';
-import {getBatchRange} from './util/getBatchRange';
-import EventTooltip from './EventTooltip';
+import {REACT_PRIORITIES} from './canvas/constants';
+import {getPriorityHeight} from './canvas/canvasUtils';
 import preprocessData from './util/preprocessData';
 import preprocessFlamechart from './util/preprocessFlamechart';
-import styles from './App.css';
-import AutoSizer from 'react-virtualized-auto-sizer';
-import {
-  COLORS,
-  REACT_PRIORITIES,
-  FLAMECHART_FRAME_HEIGHT,
-  LABEL_FIXED_WIDTH,
-  HEADER_HEIGHT_FIXED,
-} from './canvas/constants';
-
-import {ContextMenu, ContextMenuItem, useContextMenu} from './context';
 
 // TODO: Add import button but keep a static path until canvas layout is ready
 import JSON_PATH from 'url:../static/small-devtools.json';
 
-const CONTEXT_MENU_ID = 'canvas';
-
-import type {
-  FlamechartData,
-  ReactHoverContextInfo,
-  ReactMeasure,
-  ReactProfilerData,
-} from './types';
-
-type ContextMenuContextData = {|
-  data: ReactProfilerData | null,
-  flamechart: FlamechartData | null,
-  hoveredEvent: ReactHoverContextInfo | null,
-  state: PanAndZoomState,
-|};
-
-function App() {
+export default function App() {
   const [data, setData] = useState<ReactProfilerData | null>(null);
   const [flamechart, setFlamechart] = useState<FlamechartData | null>(null);
   const [schedulerCanvasHeight, setSchedulerCanvasHeight] = useState<number>(0);
@@ -86,184 +48,15 @@ function App() {
       });
   }, []);
 
-  return (
-    <div className={styles.App} style={{backgroundColor: COLORS.PAGE_BG}}>
-      <AutoSizer>
-        {({height, width}: {height: number, width: number}) => (
-          <AutoSizedCanvas
-            data={data}
-            flamechart={flamechart}
-            height={height}
-            schedulerCanvasHeight={schedulerCanvasHeight}
-            width={width}
-          />
-        )}
-      </AutoSizer>
-    </div>
-  );
-}
-
-const copySummary = (data: ReactProfilerData | null, measure: ReactMeasure) => {
-  const {batchUID, duration, priority, timestamp, type} = measure;
-
-  const [startTime, stopTime] = getBatchRange(batchUID, priority, data);
-
-  copy(
-    JSON.stringify({
-      type,
-      timestamp: prettyMilliseconds(timestamp),
-      duration: prettyMilliseconds(duration),
-      batchDuration: prettyMilliseconds(stopTime - startTime),
-    }),
-  );
-};
-
-const zoomToBatch = (
-  data: ReactProfilerData | null,
-  measure: ReactMeasure,
-  state: PanAndZoomState,
-) => {
-  const {zoomTo} = state;
-  if (!data || !zoomTo) {
-    return;
+  if (data && flamechart) {
+    return (
+      <CanvasPage
+        profilerData={data}
+        flamechart={flamechart}
+        schedulerCanvasHeight={schedulerCanvasHeight}
+      />
+    );
+  } else {
+    return <div>Loading</div>;
   }
-  const {batchUID, priority} = measure;
-  const [startTime, stopTime] = getBatchRange(batchUID, priority, data);
-  zoomTo(startTime, stopTime);
-};
-
-type AutoSizedCanvasProps = {|
-  data: ReactProfilerData | null,
-  flamechart: FlamechartData | null,
-  height: number,
-  schedulerCanvasHeight: number,
-  width: number,
-|};
-
-function AutoSizedCanvas({
-  data,
-  flamechart,
-  height,
-  schedulerCanvasHeight,
-  width,
-}: AutoSizedCanvasProps) {
-  const canvasRef = useRef<HTMLCanvasElement | null>(null);
-
-  const state = usePanAndZoom({
-    canvasRef,
-    canvasHeight: height,
-    canvasWidth: width,
-    fixedColumnWidth: LABEL_FIXED_WIDTH,
-    fixedHeaderHeight: HEADER_HEIGHT_FIXED,
-    unscaledContentWidth: data != null ? data.duration : 0,
-    unscaledContentHeight:
-      data != null
-        ? schedulerCanvasHeight +
-          flamechart.layers.length * FLAMECHART_FRAME_HEIGHT
-        : 0,
-  });
-
-  const hoveredEvent = getHoveredEvent(
-    schedulerCanvasHeight,
-    data,
-    flamechart,
-    state,
-  );
-  const [isContextMenuShown, setIsContextMenuShown] = useState<boolean>(false);
-
-  useContextMenu<ContextMenuContextData>({
-    data: {
-      data,
-      flamechart,
-      hoveredEvent,
-      state,
-    },
-    id: CONTEXT_MENU_ID,
-    onChange: setIsContextMenuShown,
-    ref: canvasRef,
-  });
-
-  useLayoutEffect(() => {
-    if (data !== null) {
-      renderCanvas(
-        data,
-        flamechart,
-        canvasRef.current,
-        width,
-        height,
-        schedulerCanvasHeight,
-        state,
-        hoveredEvent,
-      );
-    }
-  });
-
-  return (
-    <Fragment>
-      <canvas ref={canvasRef} height={height} width={width} />
-      <ContextMenu id={CONTEXT_MENU_ID}>
-        {(contextData: ContextMenuContextData) => {
-          if (contextData.hoveredEvent == null) {
-            return null;
-          }
-          const {event, flamechartNode, measure} = contextData.hoveredEvent;
-          return (
-            <Fragment>
-              {event !== null && (
-                <ContextMenuItem
-                  onClick={() => copy(event.componentName)}
-                  title="Copy component name">
-                  Copy component name
-                </ContextMenuItem>
-              )}
-              {event !== null && (
-                <ContextMenuItem
-                  onClick={() => copy(event.componentStack)}
-                  title="Copy component stack">
-                  Copy component stack
-                </ContextMenuItem>
-              )}
-              {measure !== null && (
-                <ContextMenuItem
-                  onClick={() => zoomToBatch(contextData.data, measure, state)}
-                  title="Zoom to batch">
-                  Zoom to batch
-                </ContextMenuItem>
-              )}
-              {measure !== null && (
-                <ContextMenuItem
-                  onClick={() => copySummary(contextData.data, measure)}
-                  title="Copy summary">
-                  Copy summary
-                </ContextMenuItem>
-              )}
-              {flamechartNode !== null && (
-                <ContextMenuItem
-                  onClick={() => copy(flamechartNode.node.frame.file)}
-                  title="Copy file path">
-                  Copy file path
-                </ContextMenuItem>
-              )}
-              {flamechartNode !== null && (
-                <ContextMenuItem
-                  onClick={() =>
-                    copy(
-                      `line ${flamechartNode.node.frame.line}, column ${flamechartNode.node.frame.col}`,
-                    )
-                  }
-                  title="Copy location">
-                  Copy location
-                </ContextMenuItem>
-              )}
-            </Fragment>
-          );
-        }}
-      </ContextMenu>
-      {!isContextMenuShown && (
-        <EventTooltip data={data} hoveredEvent={hoveredEvent} state={state} />
-      )}
-    </Fragment>
-  );
 }
-
-export default App;

--- a/src/App.js
+++ b/src/App.js
@@ -200,12 +200,7 @@ function AutoSizedCanvas({
 
   return (
     <Fragment>
-      <canvas
-        ref={canvasRef}
-        className={styles.Canvas}
-        height={height}
-        width={width}
-      />
+      <canvas ref={canvasRef} height={height} width={width} />
       <ContextMenu id={CONTEXT_MENU_ID}>
         {(contextData: ContextMenuContextData) => {
           if (contextData.hoveredEvent == null) {

--- a/src/CanvasPage.css
+++ b/src/CanvasPage.css
@@ -1,4 +1,4 @@
-.App {
+.CanvasPage {
   position: absolute;
   top: 0.5rem;
   bottom: 0.5rem;

--- a/src/CanvasPage.js
+++ b/src/CanvasPage.js
@@ -1,0 +1,229 @@
+// @flow
+
+import type {PanAndZoomState} from './util/usePanAndZoom';
+
+import {copy} from 'clipboard-js';
+import React, {Fragment, useLayoutEffect, useRef, useState} from 'react';
+import usePanAndZoom from './util/usePanAndZoom';
+
+import {getHoveredEvent} from './canvas/canvasUtils';
+import {renderCanvas} from './canvas/renderCanvas';
+
+import prettyMilliseconds from 'pretty-ms';
+import {getBatchRange} from './util/getBatchRange';
+import EventTooltip from './EventTooltip';
+import styles from './CanvasPage.css';
+import AutoSizer from 'react-virtualized-auto-sizer';
+import {
+  COLORS,
+  FLAMECHART_FRAME_HEIGHT,
+  LABEL_FIXED_WIDTH,
+  HEADER_HEIGHT_FIXED,
+} from './canvas/constants';
+
+import {ContextMenu, ContextMenuItem, useContextMenu} from './context';
+
+const CONTEXT_MENU_ID = 'canvas';
+
+import type {
+  FlamechartData,
+  ReactHoverContextInfo,
+  ReactMeasure,
+  ReactProfilerData,
+} from './types';
+
+type ContextMenuContextData = {|
+  data: ReactProfilerData,
+  flamechart: FlamechartData,
+  hoveredEvent: ReactHoverContextInfo | null,
+  state: PanAndZoomState,
+|};
+
+type Props = {|
+  profilerData: ReactProfilerData,
+  flamechart: FlamechartData,
+  schedulerCanvasHeight: number,
+|};
+
+function CanvasPage({profilerData, flamechart, schedulerCanvasHeight}: Props) {
+  return (
+    <div
+      className={styles.CanvasPage}
+      style={{backgroundColor: COLORS.PAGE_BG}}>
+      <AutoSizer>
+        {({height, width}: {height: number, width: number}) => (
+          <AutoSizedCanvas
+            data={profilerData}
+            flamechart={flamechart}
+            height={height}
+            schedulerCanvasHeight={schedulerCanvasHeight}
+            width={width}
+          />
+        )}
+      </AutoSizer>
+    </div>
+  );
+}
+
+const copySummary = (data: ReactProfilerData, measure: ReactMeasure) => {
+  const {batchUID, duration, priority, timestamp, type} = measure;
+
+  const [startTime, stopTime] = getBatchRange(batchUID, priority, data);
+
+  copy(
+    JSON.stringify({
+      type,
+      timestamp: prettyMilliseconds(timestamp),
+      duration: prettyMilliseconds(duration),
+      batchDuration: prettyMilliseconds(stopTime - startTime),
+    }),
+  );
+};
+
+const zoomToBatch = (
+  data: ReactProfilerData,
+  measure: ReactMeasure,
+  state: PanAndZoomState,
+) => {
+  const {zoomTo} = state;
+  if (!zoomTo) {
+    return;
+  }
+  const {batchUID, priority} = measure;
+  const [startTime, stopTime] = getBatchRange(batchUID, priority, data);
+  zoomTo(startTime, stopTime);
+};
+
+type AutoSizedCanvasProps = {|
+  data: ReactProfilerData,
+  flamechart: FlamechartData,
+  height: number,
+  schedulerCanvasHeight: number,
+  width: number,
+|};
+
+function AutoSizedCanvas({
+  data,
+  flamechart,
+  height,
+  schedulerCanvasHeight,
+  width,
+}: AutoSizedCanvasProps) {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+
+  const state = usePanAndZoom({
+    canvasRef,
+    canvasHeight: height,
+    canvasWidth: width,
+    fixedColumnWidth: LABEL_FIXED_WIDTH,
+    fixedHeaderHeight: HEADER_HEIGHT_FIXED,
+    unscaledContentWidth: data.duration,
+    unscaledContentHeight:
+      schedulerCanvasHeight +
+      flamechart.layers.length * FLAMECHART_FRAME_HEIGHT,
+  });
+
+  const hoveredEvent = getHoveredEvent(
+    schedulerCanvasHeight,
+    data,
+    flamechart,
+    state,
+  );
+  const [isContextMenuShown, setIsContextMenuShown] = useState<boolean>(false);
+
+  useContextMenu<ContextMenuContextData>({
+    data: {
+      data,
+      flamechart,
+      hoveredEvent,
+      state,
+    },
+    id: CONTEXT_MENU_ID,
+    onChange: setIsContextMenuShown,
+    ref: canvasRef,
+  });
+
+  useLayoutEffect(() => {
+    if (data !== null) {
+      renderCanvas(
+        data,
+        flamechart,
+        canvasRef.current,
+        width,
+        height,
+        schedulerCanvasHeight,
+        state,
+        hoveredEvent,
+      );
+    }
+  });
+
+  return (
+    <Fragment>
+      <canvas ref={canvasRef} height={height} width={width} />
+      <ContextMenu id={CONTEXT_MENU_ID}>
+        {(contextData: ContextMenuContextData) => {
+          if (contextData.hoveredEvent == null) {
+            return null;
+          }
+          const {event, flamechartNode, measure} = contextData.hoveredEvent;
+          return (
+            <Fragment>
+              {event !== null && (
+                <ContextMenuItem
+                  onClick={() => copy(event.componentName)}
+                  title="Copy component name">
+                  Copy component name
+                </ContextMenuItem>
+              )}
+              {event !== null && (
+                <ContextMenuItem
+                  onClick={() => copy(event.componentStack)}
+                  title="Copy component stack">
+                  Copy component stack
+                </ContextMenuItem>
+              )}
+              {measure !== null && (
+                <ContextMenuItem
+                  onClick={() => zoomToBatch(contextData.data, measure, state)}
+                  title="Zoom to batch">
+                  Zoom to batch
+                </ContextMenuItem>
+              )}
+              {measure !== null && (
+                <ContextMenuItem
+                  onClick={() => copySummary(contextData.data, measure)}
+                  title="Copy summary">
+                  Copy summary
+                </ContextMenuItem>
+              )}
+              {flamechartNode !== null && (
+                <ContextMenuItem
+                  onClick={() => copy(flamechartNode.node.frame.file)}
+                  title="Copy file path">
+                  Copy file path
+                </ContextMenuItem>
+              )}
+              {flamechartNode !== null && (
+                <ContextMenuItem
+                  onClick={() =>
+                    copy(
+                      `line ${flamechartNode.node.frame.line}, column ${flamechartNode.node.frame.col}`,
+                    )
+                  }
+                  title="Copy location">
+                  Copy location
+                </ContextMenuItem>
+              )}
+            </Fragment>
+          );
+        }}
+      </ContextMenu>
+      {!isContextMenuShown && (
+        <EventTooltip data={data} hoveredEvent={hoveredEvent} state={state} />
+      )}
+    </Fragment>
+  );
+}
+
+export default CanvasPage;

--- a/src/EventTooltip.js
+++ b/src/EventTooltip.js
@@ -18,7 +18,7 @@ import useSmartTooltip from './util/useSmartTooltip';
 import styles from './EventTooltip.css';
 
 type Props = {|
-  data: ReactProfilerData | null,
+  data: ReactProfilerData,
   hoveredEvent: ReactHoverContextInfo | null,
   state: PanAndZoomState,
 |};
@@ -118,7 +118,7 @@ const TooltipFlamechartNode = ({
   flamechartNode,
   tooltipRef,
 }: {
-  data: ReactProfilerData | null,
+  data: ReactProfilerData,
   flamechartNode: FlamechartFrame,
   tooltipRef: Return<typeof useRef>,
 }) => {
@@ -149,7 +149,7 @@ const TooltipReactEvent = ({
   tooltipRef,
 }: {
   color: string,
-  data: ReactProfilerData | null,
+  data: ReactProfilerData,
   event: ReactEvent,
   tooltipRef: Return<typeof useRef>,
 }) => {
@@ -206,7 +206,7 @@ const TooltipReactMeasure = ({
   measure,
   tooltipRef,
 }: {
-  data: ReactProfilerData | null,
+  data: ReactProfilerData,
   measure: ReactMeasure,
   tooltipRef: Return<typeof useRef>,
 }) => {

--- a/src/ImportPage.js
+++ b/src/ImportPage.js
@@ -4,7 +4,6 @@ import type {TimelineEvent} from './speedscope/import/chrome';
 import type {FlamechartData, ReactProfilerData} from './types';
 
 import React, {useEffect} from 'react';
-import {unstable_batchedUpdates} from 'react-dom';
 
 import preprocessData from './util/preprocessData';
 import preprocessFlamechart from './util/preprocessFlamechart';
@@ -30,11 +29,9 @@ export default function ImportPage({onDataImported}: Props) {
         events = events.filter(Boolean).sort((a, b) => (a.ts > b.ts ? 1 : -1));
 
         if (events.length > 0) {
-          unstable_batchedUpdates(() => {
-            const processedData = preprocessData(events);
-            const processedFlamechart = preprocessFlamechart(events);
-            onDataImported(processedData, processedFlamechart);
-          });
+          const processedData = preprocessData(events);
+          const processedFlamechart = preprocessFlamechart(events);
+          onDataImported(processedData, processedFlamechart);
         }
       });
   }, []);

--- a/src/ImportPage.js
+++ b/src/ImportPage.js
@@ -1,0 +1,48 @@
+// @flow
+
+import type {TimelineEvent} from './speedscope/import/chrome';
+import type {FlamechartData, ReactProfilerData} from './types';
+
+import React, {useEffect} from 'react';
+import {unstable_batchedUpdates} from 'react-dom';
+
+import preprocessData from './util/preprocessData';
+import preprocessFlamechart from './util/preprocessFlamechart';
+
+// TODO: Add import button but keep a static path until canvas layout is ready
+import JSON_PATH from 'url:../static/small-devtools.json';
+
+type Props = {|
+  onDataImported: (
+    profilerData: ReactProfilerData,
+    flamechart: FlamechartData,
+  ) => void,
+|};
+
+export default function ImportPage({onDataImported}: Props) {
+  useEffect(() => {
+    fetch(JSON_PATH)
+      .then(res => res.json())
+      .then((events: TimelineEvent[]) => {
+        // Filter null entries and sort by timestamp.
+        // I would not expect to have to do either of this,
+        // but some of the data being passed in requires it.
+        events = events.filter(Boolean).sort((a, b) => (a.ts > b.ts ? 1 : -1));
+
+        if (events.length > 0) {
+          unstable_batchedUpdates(() => {
+            const processedData = preprocessData(events);
+            const processedFlamechart = preprocessFlamechart(events);
+            onDataImported(processedData, processedFlamechart);
+          });
+        }
+      });
+  }, []);
+
+  return (
+    <div>
+      LOADING. TODO: Turn this into an import page. This page currently just
+      immediately loads a JSON file.
+    </div>
+  );
+}

--- a/src/canvas/canvasUtils.js
+++ b/src/canvas/canvasUtils.js
@@ -29,11 +29,7 @@ import {
 } from '../util/usePanAndZoom';
 
 // hidpi canvas: https://www.html5rocks.com/en/tutorials/canvas/hidpi/
-export function configureRetinaCanvas(
-  canvas: HTMLCanvasElement,
-  height: number,
-  width: number,
-): number {
+function configureRetinaCanvas(canvas, height, width) {
   const dpr: number = window.devicePixelRatio || 1;
   canvas.width = width * dpr;
   canvas.height = height * dpr;
@@ -89,7 +85,7 @@ export function getTimeTickInterval(zoomLevel: number) {
   return interval;
 }
 
-export const cachedFlamegraphTextWidths = new Map();
+const cachedFlamegraphTextWidths = new Map();
 export const trimFlamegraphText = (
   context: CanvasRenderingContext2D,
   text: string,

--- a/src/canvas/canvasUtils.js
+++ b/src/canvas/canvasUtils.js
@@ -110,8 +110,8 @@ export const trimFlamegraphText = (
 
 export function getHoveredEvent(
   schedulerCanvasHeight: number,
-  data: ReactProfilerData | null,
-  flamechart: FlamechartData | null,
+  data: ReactProfilerData,
+  flamechart: FlamechartData,
   state: PanAndZoomState,
 ): ReactHoverContextInfo | null {
   const {canvasMouseX, canvasMouseY, offsetY} = state;
@@ -121,117 +121,113 @@ export function getHoveredEvent(
   }
 
   if (canvasMouseY + offsetY < schedulerCanvasHeight) {
-    if (data != null) {
-      const adjustedCanvasMouseY = canvasMouseY - HEADER_HEIGHT_FIXED + offsetY;
-      let priorityMinY = HEADER_HEIGHT_FIXED;
-      let priorityIndex = null;
-      let priority: ReactPriority = 'unscheduled';
-      for (let index = 0; index < REACT_PRIORITIES.length; index++) {
-        priority = REACT_PRIORITIES[index];
+    const adjustedCanvasMouseY = canvasMouseY - HEADER_HEIGHT_FIXED + offsetY;
+    let priorityMinY = HEADER_HEIGHT_FIXED;
+    let priorityIndex = null;
+    let priority: ReactPriority = 'unscheduled';
+    for (let index = 0; index < REACT_PRIORITIES.length; index++) {
+      priority = REACT_PRIORITIES[index];
 
-        const priorityHeight = getPriorityHeight(data, priority);
-        if (
-          adjustedCanvasMouseY >= priorityMinY &&
-          adjustedCanvasMouseY <= priorityMinY + priorityHeight
-        ) {
-          priorityIndex = index;
-          break;
+      const priorityHeight = getPriorityHeight(data, priority);
+      if (
+        adjustedCanvasMouseY >= priorityMinY &&
+        adjustedCanvasMouseY <= priorityMinY + priorityHeight
+      ) {
+        priorityIndex = index;
+        break;
+      }
+      priorityMinY += priorityHeight;
+    }
+
+    if (priorityIndex === null) {
+      return null;
+    }
+
+    const baseY = priorityMinY - offsetY;
+    const eventMinY = baseY + REACT_GUTTER_SIZE / 2;
+    const eventMaxY = eventMinY + REACT_EVENT_SIZE + REACT_GUTTER_SIZE;
+    const measureMinY = eventMaxY;
+    const measureMaxY = measureMinY + REACT_WORK_SIZE + REACT_GUTTER_SIZE;
+
+    let events = null;
+    let measures = null;
+    if (canvasMouseY >= eventMinY && canvasMouseY <= eventMaxY) {
+      events = data[priority].events;
+    } else if (canvasMouseY >= measureMinY && canvasMouseY <= measureMaxY) {
+      measures = data[priority].measures;
+    }
+
+    if (events !== null) {
+      for (let index = events.length - 1; index >= 0; index--) {
+        const event = events[index];
+        const {timestamp} = event;
+
+        const eventX = timestampToPosition(timestamp, state);
+        const startX = eventX - REACT_EVENT_SIZE / 2;
+        const stopX = eventX + REACT_EVENT_SIZE / 2;
+        if (canvasMouseX >= startX && canvasMouseX <= stopX) {
+          return {
+            event,
+            flamechartNode: null,
+            measure: null,
+            priorityIndex,
+            data,
+          };
         }
-        priorityMinY += priorityHeight;
       }
+    } else if (measures !== null) {
+      // Because data ranges may overlap, we want to find the last intersecting item.
+      // This will always be the one on "top" (the one the user is hovering over).
+      for (let index = measures.length - 1; index >= 0; index--) {
+        const measure = measures[index];
+        const {duration, timestamp} = measure;
 
-      if (priorityIndex === null) {
-        return null;
-      }
+        const pointerTime = positionToTimestamp(canvasMouseX, state);
 
-      const baseY = priorityMinY - offsetY;
-      const eventMinY = baseY + REACT_GUTTER_SIZE / 2;
-      const eventMaxY = eventMinY + REACT_EVENT_SIZE + REACT_GUTTER_SIZE;
-      const measureMinY = eventMaxY;
-      const measureMaxY = measureMinY + REACT_WORK_SIZE + REACT_GUTTER_SIZE;
-
-      let events = null;
-      let measures = null;
-      if (canvasMouseY >= eventMinY && canvasMouseY <= eventMaxY) {
-        events = data[priority].events;
-      } else if (canvasMouseY >= measureMinY && canvasMouseY <= measureMaxY) {
-        measures = data[priority].measures;
-      }
-
-      if (events !== null) {
-        for (let index = events.length - 1; index >= 0; index--) {
-          const event = events[index];
-          const {timestamp} = event;
-
-          const eventX = timestampToPosition(timestamp, state);
-          const startX = eventX - REACT_EVENT_SIZE / 2;
-          const stopX = eventX + REACT_EVENT_SIZE / 2;
-          if (canvasMouseX >= startX && canvasMouseX <= stopX) {
-            return {
-              event,
-              flamechartNode: null,
-              measure: null,
-              priorityIndex,
-              data,
-            };
-          }
-        }
-      } else if (measures !== null) {
-        // Because data ranges may overlap, we want to find the last intersecting item.
-        // This will always be the one on "top" (the one the user is hovering over).
-        for (let index = measures.length - 1; index >= 0; index--) {
-          const measure = measures[index];
-          const {duration, timestamp} = measure;
-
-          const pointerTime = positionToTimestamp(canvasMouseX, state);
-
-          if (pointerTime >= timestamp && pointerTime <= timestamp + duration) {
-            return {
-              event: null,
-              flamechartNode: null,
-              measure,
-              priorityIndex,
-              data,
-            };
-          }
+        if (pointerTime >= timestamp && pointerTime <= timestamp + duration) {
+          return {
+            event: null,
+            flamechartNode: null,
+            measure,
+            priorityIndex,
+            data,
+          };
         }
       }
     }
   } else {
-    if (flamechart !== null) {
-      const layerIndex = Math.floor(
-        (canvasMouseY + offsetY - HEADER_HEIGHT_FIXED - schedulerCanvasHeight) /
-          FLAMECHART_FRAME_HEIGHT,
-      );
-      const layer = flamechart.layers[layerIndex];
+    const layerIndex = Math.floor(
+      (canvasMouseY + offsetY - HEADER_HEIGHT_FIXED - schedulerCanvasHeight) /
+        FLAMECHART_FRAME_HEIGHT,
+    );
+    const layer = flamechart.layers[layerIndex];
 
-      if (layer != null) {
-        let startIndex = 0;
-        let stopIndex = layer.length - 1;
-        while (startIndex <= stopIndex) {
-          const currentIndex = Math.floor((startIndex + stopIndex) / 2);
-          const flamechartNode = layer[currentIndex];
+    if (layer != null) {
+      let startIndex = 0;
+      let stopIndex = layer.length - 1;
+      while (startIndex <= stopIndex) {
+        const currentIndex = Math.floor((startIndex + stopIndex) / 2);
+        const flamechartNode = layer[currentIndex];
 
-          const {end, start} = flamechartNode;
+        const {end, start} = flamechartNode;
 
-          const width = durationToWidth((end - start) / 1000, state);
-          const x = Math.floor(timestampToPosition(start / 1000, state));
+        const width = durationToWidth((end - start) / 1000, state);
+        const x = Math.floor(timestampToPosition(start / 1000, state));
 
-          if (x <= canvasMouseX && x + width >= canvasMouseX) {
-            return {
-              event: null,
-              flamechartNode,
-              measure: null,
-              priorityIndex: null,
-              data,
-            };
-          }
+        if (x <= canvasMouseX && x + width >= canvasMouseX) {
+          return {
+            event: null,
+            flamechartNode,
+            measure: null,
+            priorityIndex: null,
+            data,
+          };
+        }
 
-          if (x > canvasMouseX) {
-            stopIndex = currentIndex - 1;
-          } else {
-            startIndex = currentIndex + 1;
-          }
+        if (x > canvasMouseX) {
+          stopIndex = currentIndex - 1;
+        } else {
+          startIndex = currentIndex + 1;
         }
       }
     }

--- a/src/canvas/renderCanvas.js
+++ b/src/canvas/renderCanvas.js
@@ -77,7 +77,7 @@ import {
 //                  '──────────────────────────
 //
 
-export const renderReact = ({
+const renderReact = ({
   baseY,
   canvasWidth,
   context,

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,13 @@
-import {createElement} from 'react';
+import React from 'react';
 import {render} from 'react-dom';
 import App from './App';
 import './index.css';
 
 const container = document.getElementById('root');
 
-render(createElement(App), container);
+render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+  container,
+);


### PR DESCRIPTION
## Summary

Breaks App.js into CanvasPage and ImportPage. Largely just code reshuffling.

* App.js now has a basic routing algorithm: display ImportPage if no data has been loaded, and CanvasPage once all data is loaded.
* CanvasPage can now be assured of non-null `data` and `flamechart`, and the types have been updated accordingly. 
* ImportPage simply loads the data from the same JSON data as in App.js.

Misc:
1. Disable some function exports so that Flow type inference can work better.
1. Wrap app in `StrictMode` to ensure concurrent mode compatibility as we work.

Unblocks https://github.com/MLH-Fellowship/scheduling-profiler-prototype/issues/9.

## Test plan

1. `yarn start` works.
1. CI.