### PR TITLE
Break renderCanvas into small render* functions

### DIFF
--- a/src/CanvasPage.js
+++ b/src/CanvasPage.js
@@ -144,7 +144,7 @@ function AutoSizedCanvas({
   });
 
   useLayoutEffect(() => {
-    if (data !== null) {
+    if (canvasRef.current !== null) {
       renderCanvas(
         data,
         flamechart,

--- a/src/canvas/canvasUtils.js
+++ b/src/canvas/canvasUtils.js
@@ -110,8 +110,8 @@ export const trimFlamegraphText = (
 
 export function getHoveredEvent(
   schedulerCanvasHeight: number,
-  data: ReactProfilerData,
-  flamechart: FlamechartData,
+  data: $ReadOnly<ReactProfilerData>,
+  flamechart: $ReadOnly<FlamechartData>,
   state: PanAndZoomState,
 ): ReactHoverContextInfo | null {
   const {canvasMouseX, canvasMouseY, offsetY} = state;
@@ -238,7 +238,7 @@ export function getHoveredEvent(
 
 const cachedPriorityHeights = new Map();
 export const getPriorityHeight = (
-  data: ReactProfilerData,
+  data: $ReadOnly<ReactProfilerData>,
   priority: ReactPriority,
 ): number => {
   if (cachedPriorityHeights.has(priority)) {

--- a/src/canvas/renderCanvas.js
+++ b/src/canvas/renderCanvas.js
@@ -4,6 +4,8 @@ import type {
   ReactProfilerData,
   FlamechartData,
   ReactHoverContextInfo,
+  ReactEvent,
+  ReactMeasure,
 } from '../types';
 import type {PanAndZoomState} from '../util/usePanAndZoom';
 
@@ -217,14 +219,14 @@ const renderReact = ({
 // TODO Passing "state" directly breaks memoization for e.g. mouse moves
 export const renderCanvas = memoize(
   (
-    data: ReactProfilerData,
-    flamechart: FlamechartData | null,
-    canvas: HTMLCanvasElement | null,
+    data: $ReadOnly<ReactProfilerData>,
+    flamechart: $ReadOnly<FlamechartData> | null,
+    canvas: HTMLCanvasElement,
     canvasWidth: number,
     canvasHeight: number,
     schedulerCanvasHeight: number,
-    state: PanAndZoomState,
-    hoveredEvent: ReactHoverContextInfo | null,
+    state: $ReadOnly<PanAndZoomState>,
+    hoveredEvent: $ReadOnly<ReactHoverContextInfo> | null,
   ) => {
     const {offsetX, offsetY, zoomLevel} = state;
 

--- a/src/canvas/renderCanvas.js
+++ b/src/canvas/renderCanvas.js
@@ -473,7 +473,7 @@ function renderAxisMarkers(
 export const renderCanvas = memoize(
   (
     data: $ReadOnly<ReactProfilerData>,
-    flamechart: $ReadOnly<FlamechartData> | null,
+    flamechart: $ReadOnly<FlamechartData>,
     canvas: HTMLCanvasElement,
     canvasWidth: number,
     canvasHeight: number,
@@ -502,17 +502,15 @@ export const renderCanvas = memoize(
 
     // Flame graph data renders below the prioritized React data.
     // TODO Timestamp alignment is off by a few hundred me from our user timing marks; why?
-    if (flamechart !== null) {
-      renderFlamechart(
-        context,
-        flamechart,
-        state,
-        hoveredEvent,
-        canvasWidth,
-        canvasHeight,
-        HEADER_HEIGHT_FIXED + schedulerCanvasHeight - offsetY,
-      );
-    }
+    renderFlamechart(
+      context,
+      flamechart,
+      state,
+      hoveredEvent,
+      canvasWidth,
+      canvasHeight,
+      HEADER_HEIGHT_FIXED + schedulerCanvasHeight - offsetY,
+    );
 
     // LEFT: Priority labels
     // Render them last, on top of everything else, to account for things scrolled beneath them.

--- a/src/canvas/renderCanvas.js
+++ b/src/canvas/renderCanvas.js
@@ -79,7 +79,90 @@ import {
 //                  '──────────────────────────
 //
 
-const renderReact = ({
+function renderBackgroundFills(context, canvasWidth, canvasHeight) {
+  // Fill the canvas with the background color
+  context.fillStyle = COLORS.BACKGROUND;
+  context.fillRect(0, 0, canvasWidth, canvasHeight);
+}
+
+/**
+ * Render all charting data (once it's loaded and processed) within the
+ * "scrollable" region.
+ */
+// TODO (windowing) We can avoid rendering all of this if we've scrolled some of it off screen.
+function renderReactMarksAndMeasures(
+  context,
+  data,
+  state,
+  hoveredEvent,
+  canvasWidth,
+  canvasHeight,
+  canvasStartY,
+) {
+  let priorityMinY = canvasStartY;
+
+  REACT_PRIORITIES.forEach((priority, priorityIndex) => {
+    const currentPriority = data[priority];
+
+    let baseY = priorityMinY + REACT_GUTTER_SIZE;
+
+    if (currentPriority.events.length > 0) {
+      currentPriority.events.forEach(event => {
+        const showHoverHighlight = hoveredEvent && hoveredEvent.event === event;
+        renderSingleReactMarkOrMeasure({
+          baseY,
+          canvasWidth,
+          context,
+          eventOrMeasure: event,
+          showGroupHighlight: false,
+          showHoverHighlight,
+          priorityIndex,
+          state,
+        });
+      });
+
+      // Draw the hovered and/or selected items on top so they stand out.
+      // This is helpful if there are multiple (overlapping) items close to each other.
+      if (hoveredEvent !== null && hoveredEvent.event !== null) {
+        renderSingleReactMarkOrMeasure({
+          baseY,
+          canvasWidth,
+          context,
+          eventOrMeasure: hoveredEvent.event,
+          showGroupHighlight: false,
+          showHoverHighlight: true,
+          priorityIndex: hoveredEvent.priorityIndex,
+          state,
+        });
+      }
+
+      baseY += REACT_EVENT_SIZE + REACT_GUTTER_SIZE;
+    }
+
+    currentPriority.measures.forEach(measure => {
+      const showHoverHighlight =
+        hoveredEvent && hoveredEvent.measure === measure;
+      const showGroupHighlight =
+        hoveredEvent &&
+        hoveredEvent.measure !== null &&
+        hoveredEvent.measure.batchUID === measure.batchUID;
+      renderSingleReactMarkOrMeasure({
+        baseY,
+        canvasWidth,
+        context,
+        eventOrMeasure: measure,
+        priorityIndex,
+        showGroupHighlight,
+        showHoverHighlight,
+        state,
+      });
+    });
+
+    priorityMinY += getPriorityHeight(data, priority);
+  });
+}
+
+function renderSingleReactMarkOrMeasure({
   baseY,
   canvasWidth,
   context,
@@ -88,7 +171,7 @@ const renderReact = ({
   showGroupHighlight,
   showHoverHighlight,
   state,
-}) => {
+}) {
   const {timestamp, type} = eventOrMeasure;
   const {offsetY} = state;
 
@@ -214,7 +297,177 @@ const renderReact = ({
       console.warn(`Unexpected event or measure type "${type}"`);
       break;
   }
-};
+}
+
+function renderFlamechart(
+  context,
+  flamechart,
+  state,
+  hoveredEvent,
+  canvasWidth,
+  canvasHeight,
+  /** y coord on canvas to start painting at */
+  canvasStartY,
+) {
+  context.textAlign = 'left';
+  context.textBaseline = 'middle';
+  context.font = `${FLAMECHART_FONT_SIZE}px sans-serif`;
+
+  for (let i = 0; i < flamechart.layers.length; i++) {
+    const nodes = flamechart.layers[i];
+
+    const layerY = Math.floor(canvasStartY + i * FLAMECHART_FRAME_HEIGHT);
+    if (
+      layerY + FLAMECHART_FRAME_HEIGHT < HEADER_HEIGHT_FIXED ||
+      canvasHeight < layerY
+    ) {
+      continue; // Not in view
+    }
+
+    for (let j = 0; j < nodes.length; j++) {
+      const {end, node, start} = nodes[j];
+      const {name} = node.frame;
+
+      const showHoverHighlight =
+        hoveredEvent && hoveredEvent.flamechartNode === nodes[j];
+
+      const width = durationToWidth((end - start) / 1000, state);
+      if (width <= 0) {
+        return; // Too small to render at this zoom level
+      }
+
+      const x = Math.floor(timestampToPosition(start / 1000, state));
+      if (x + width < 0 || canvasWidth < x) {
+        continue; // Not in view
+      }
+
+      context.fillStyle = showHoverHighlight
+        ? COLORS.FLAME_GRAPH_HOVER
+        : COLORS.FLAME_GRAPH;
+
+      context.fillRect(
+        x,
+        layerY,
+        Math.floor(width - REACT_PRIORITY_BORDER_SIZE),
+        Math.floor(FLAMECHART_FRAME_HEIGHT - REACT_PRIORITY_BORDER_SIZE),
+      );
+
+      if (width > FLAMECHART_TEXT_PADDING * 2) {
+        const trimmedName = trimFlamegraphText(
+          context,
+          name,
+          width - FLAMECHART_TEXT_PADDING * 2 + (x < 0 ? x : 0),
+        );
+        if (trimmedName !== null) {
+          context.fillStyle = COLORS.PRIORITY_LABEL;
+          context.fillText(
+            trimmedName,
+            x + FLAMECHART_TEXT_PADDING - (x < 0 ? x : 0),
+            layerY + FLAMECHART_FRAME_HEIGHT / 2,
+          );
+        }
+      }
+    }
+  }
+}
+
+function renderPriorityLabels(context, data, canvasWidth, canvasStartY) {
+  let y = canvasStartY;
+
+  REACT_PRIORITIES.forEach((priority, priorityIndex) => {
+    const priorityHeight = getPriorityHeight(data, priority);
+
+    if (priorityHeight === 0) {
+      return;
+    }
+
+    context.fillStyle = COLORS.PRIORITY_BACKGROUND;
+    context.fillRect(
+      0,
+      Math.floor(y),
+      Math.floor(LABEL_FIXED_WIDTH),
+      priorityHeight,
+    );
+
+    context.fillStyle = COLORS.PRIORITY_BORDER;
+    context.fillRect(
+      0,
+      Math.floor(y + priorityHeight),
+      canvasWidth,
+      REACT_PRIORITY_BORDER_SIZE,
+    );
+
+    context.fillStyle = COLORS.PRIORITY_BORDER;
+    context.fillRect(
+      Math.floor(LABEL_FIXED_WIDTH) - REACT_PRIORITY_BORDER_SIZE,
+      Math.floor(y),
+      REACT_PRIORITY_BORDER_SIZE,
+      priorityHeight,
+    );
+
+    context.fillStyle = COLORS.PRIORITY_LABEL;
+    context.textAlign = 'left';
+    context.textBaseline = 'middle';
+    context.font = `${LABEL_FONT_SIZE}px sans-serif`;
+    context.fillText(priority, 4, y + priorityHeight / 2);
+
+    y += priorityHeight + REACT_PRIORITY_BORDER_SIZE;
+  });
+}
+
+function renderAxisMarkers(
+  context,
+  state,
+  canvasWidth,
+  panOffsetX,
+  panZoomLevel,
+) {
+  context.fillStyle = COLORS.BACKGROUND;
+  context.fillRect(0, 0, canvasWidth, HEADER_HEIGHT_FIXED);
+
+  context.fillStyle = COLORS.PRIORITY_BORDER;
+  context.fillRect(0, MARKER_HEIGHT, canvasWidth, REACT_PRIORITY_BORDER_SIZE);
+
+  // Charting data renders within this region of pixels as "scrollable" content.
+  // Time markers (top) and priority labels (left) are fixed content.
+  const scrollableCanvasWidth = canvasWidth - LABEL_FIXED_WIDTH;
+
+  const interval = getTimeTickInterval(panZoomLevel);
+  const intervalSize = interval * panZoomLevel;
+  const firstIntervalPosition =
+    0 - panOffsetX + Math.floor(panOffsetX / intervalSize) * intervalSize;
+
+  for (
+    let i = firstIntervalPosition;
+    i < scrollableCanvasWidth;
+    i += intervalSize
+  ) {
+    if (i > 0) {
+      const markerTimestamp = positionToTimestamp(i + LABEL_FIXED_WIDTH, state);
+      const markerLabel = Math.round(markerTimestamp);
+
+      const x = LABEL_FIXED_WIDTH + i;
+
+      context.fillStyle = COLORS.PRIORITY_BORDER;
+      context.fillRect(
+        x,
+        MARKER_HEIGHT - MARKER_TICK_HEIGHT,
+        REACT_PRIORITY_BORDER_SIZE,
+        MARKER_TICK_HEIGHT,
+      );
+
+      context.fillStyle = COLORS.TIME_MARKER_LABEL;
+      context.textAlign = 'right';
+      context.textBaseline = 'middle';
+      context.font = `${MARKER_FONT_SIZE}px sans-serif`;
+      context.fillText(
+        `${markerLabel}ms`,
+        x - MARKER_TEXT_PADDING,
+        MARKER_HEIGHT / 2,
+      );
+    }
+  }
+}
 
 // TODO Passing "state" directly breaks memoization for e.g. mouse moves
 export const renderCanvas = memoize(
@@ -224,7 +477,8 @@ export const renderCanvas = memoize(
     canvas: HTMLCanvasElement,
     canvasWidth: number,
     canvasHeight: number,
-    schedulerCanvasHeight: number,
+    /** Precomputed height of marks and measures canvas section */
+    schedulerCanvasHeight: number, // TODO: Figure out why this can't be calculated here
     state: $ReadOnly<PanAndZoomState>,
     hoveredEvent: $ReadOnly<ReactHoverContextInfo> | null,
   ) => {
@@ -232,250 +486,47 @@ export const renderCanvas = memoize(
 
     const context = getCanvasContext(canvas, canvasHeight, canvasWidth, true);
 
-    // Fill the canvas with the background color
-    context.fillStyle = COLORS.BACKGROUND;
-    context.fillRect(0, 0, canvasWidth, canvasHeight);
+    renderBackgroundFills(context, canvasWidth, canvasHeight);
 
-    // Charting data renders within this region of pixels as "scrollable" content.
-    // Time markers (top) and priority labels (left) are fixed content.
-    const scrollableCanvasWidth = canvasWidth - LABEL_FIXED_WIDTH;
-
-    let y = 0;
-
-    const interval = getTimeTickInterval(zoomLevel);
-    const intervalSize = interval * zoomLevel;
-    const firstIntervalPosition =
-      0 - offsetX + Math.floor(offsetX / intervalSize) * intervalSize;
-
-    // Render all charting data (once it's loaded and processed) within the "scrollable" region.
-    // TODO (windowing) We can avoid rendering all of this if we've scrolled some of it off screen.
-    if (data != null) {
-      // Time markers do not scroll off screen; they are always rendered at a fixed vertical position.
-      y = HEADER_HEIGHT_FIXED - offsetY;
-
-      let priorityMinY = HEADER_HEIGHT_FIXED;
-
-      REACT_PRIORITIES.forEach((priority, priorityIndex) => {
-        const currentPriority = data[priority];
-
-        let baseY = priorityMinY + REACT_GUTTER_SIZE;
-
-        if (currentPriority.events.length > 0) {
-          currentPriority.events.forEach(event => {
-            const showHoverHighlight =
-              hoveredEvent && hoveredEvent.event === event;
-            renderReact({
-              baseY,
-              canvasWidth,
-              context,
-              eventOrMeasure: event,
-              showGroupHighlight: false,
-              showHoverHighlight,
-              priorityIndex,
-              state,
-            });
-          });
-
-          // Draw the hovered and/or selected items on top so they stand out.
-          // This is helpful if there are multiple (overlapping) items close to each other.
-          if (hoveredEvent !== null && hoveredEvent.event !== null) {
-            renderReact({
-              baseY,
-              canvasWidth,
-              context,
-              eventOrMeasure: hoveredEvent.event,
-              showGroupHighlight: false,
-              showHoverHighlight: true,
-              priorityIndex: hoveredEvent.priorityIndex,
-              state,
-            });
-          }
-
-          baseY += REACT_EVENT_SIZE + REACT_GUTTER_SIZE;
-        }
-
-        currentPriority.measures.forEach(measure => {
-          const showHoverHighlight =
-            hoveredEvent && hoveredEvent.measure === measure;
-          const showGroupHighlight =
-            hoveredEvent &&
-            hoveredEvent.measure !== null &&
-            hoveredEvent.measure.batchUID === measure.batchUID;
-          renderReact({
-            baseY,
-            canvasWidth,
-            context,
-            eventOrMeasure: measure,
-            priorityIndex,
-            showGroupHighlight,
-            showHoverHighlight,
-            state,
-          });
-        });
-
-        priorityMinY += getPriorityHeight(data, priority);
-      });
-    }
+    renderReactMarksAndMeasures(
+      context,
+      data,
+      state,
+      hoveredEvent,
+      canvasWidth,
+      canvasHeight,
+      // Time markers do not scroll off screen; they are always rendered at a
+      // fixed vertical position.
+      HEADER_HEIGHT_FIXED,
+    );
 
     // Flame graph data renders below the prioritized React data.
     // TODO Timestamp alignment is off by a few hundred me from our user timing marks; why?
     if (flamechart !== null) {
-      context.textAlign = 'left';
-      context.textBaseline = 'middle';
-      context.font = `${FLAMECHART_FONT_SIZE}px sans-serif`;
-
-      for (let i = 0; i < flamechart.layers.length; i++) {
-        const nodes = flamechart.layers[i];
-
-        const layerY = Math.floor(
-          HEADER_HEIGHT_FIXED +
-            schedulerCanvasHeight +
-            i * FLAMECHART_FRAME_HEIGHT -
-            offsetY,
-        );
-        if (
-          layerY + FLAMECHART_FRAME_HEIGHT < HEADER_HEIGHT_FIXED ||
-          canvasHeight < layerY
-        ) {
-          continue; // Not in view
-        }
-
-        for (let j = 0; j < nodes.length; j++) {
-          const {end, node, start} = nodes[j];
-          const {name} = node.frame;
-
-          const showHoverHighlight =
-            hoveredEvent && hoveredEvent.flamechartNode === nodes[j];
-
-          const width = durationToWidth((end - start) / 1000, state);
-          if (width <= 0) {
-            return; // Too small to render at this zoom level
-          }
-
-          const x = Math.floor(timestampToPosition(start / 1000, state));
-          if (x + width < 0 || canvasWidth < x) {
-            continue; // Not in view
-          }
-
-          context.fillStyle = showHoverHighlight
-            ? COLORS.FLAME_GRAPH_HOVER
-            : COLORS.FLAME_GRAPH;
-
-          context.fillRect(
-            x,
-            layerY,
-            Math.floor(width - REACT_PRIORITY_BORDER_SIZE),
-            Math.floor(FLAMECHART_FRAME_HEIGHT - REACT_PRIORITY_BORDER_SIZE),
-          );
-
-          if (width > FLAMECHART_TEXT_PADDING * 2) {
-            const trimmedName = trimFlamegraphText(
-              context,
-              name,
-              width - FLAMECHART_TEXT_PADDING * 2 + (x < 0 ? x : 0),
-            );
-            if (trimmedName !== null) {
-              context.fillStyle = COLORS.PRIORITY_LABEL;
-              context.fillText(
-                trimmedName,
-                x + FLAMECHART_TEXT_PADDING - (x < 0 ? x : 0),
-                layerY + FLAMECHART_FRAME_HEIGHT / 2,
-              );
-            }
-          }
-        }
-      }
+      renderFlamechart(
+        context,
+        flamechart,
+        state,
+        hoveredEvent,
+        canvasWidth,
+        canvasHeight,
+        HEADER_HEIGHT_FIXED + schedulerCanvasHeight - offsetY,
+      );
     }
 
     // LEFT: Priority labels
-    // Priority labels do not scroll off screen; they are always rendered at a fixed horizontal position.
     // Render them last, on top of everything else, to account for things scrolled beneath them.
-    y = HEADER_HEIGHT_FIXED - offsetY;
-
-    REACT_PRIORITIES.forEach((priority, priorityIndex) => {
-      const priorityHeight = getPriorityHeight(data, priority);
-
-      if (priorityHeight === 0) {
-        return;
-      }
-
-      context.fillStyle = COLORS.PRIORITY_BACKGROUND;
-      context.fillRect(
-        0,
-        Math.floor(y),
-        Math.floor(LABEL_FIXED_WIDTH),
-        priorityHeight,
-      );
-
-      context.fillStyle = COLORS.PRIORITY_BORDER;
-      context.fillRect(
-        0,
-        Math.floor(y + priorityHeight),
-        canvasWidth,
-        REACT_PRIORITY_BORDER_SIZE,
-      );
-
-      context.fillStyle = COLORS.PRIORITY_BORDER;
-      context.fillRect(
-        Math.floor(LABEL_FIXED_WIDTH) - REACT_PRIORITY_BORDER_SIZE,
-        Math.floor(y),
-        REACT_PRIORITY_BORDER_SIZE,
-        priorityHeight,
-      );
-
-      context.fillStyle = COLORS.PRIORITY_LABEL;
-      context.textAlign = 'left';
-      context.textBaseline = 'middle';
-      context.font = `${LABEL_FONT_SIZE}px sans-serif`;
-      context.fillText(priority, 4, y + priorityHeight / 2);
-
-      y += priorityHeight + REACT_PRIORITY_BORDER_SIZE;
-    });
+    renderPriorityLabels(
+      context,
+      data,
+      canvasWidth,
+      HEADER_HEIGHT_FIXED - offsetY,
+    );
 
     // TOP: Time markers
     // Time markers do not scroll off screen; they are always rendered at a fixed vertical position.
     // Render them last, on top of everything else, to account for things scrolled beneath them.
-    y = 0;
-
-    context.fillStyle = COLORS.BACKGROUND;
-    context.fillRect(0, 0, canvasWidth, HEADER_HEIGHT_FIXED);
-
-    context.fillStyle = COLORS.PRIORITY_BORDER;
-    context.fillRect(0, MARKER_HEIGHT, canvasWidth, REACT_PRIORITY_BORDER_SIZE);
-
     // Draw time marker text on top of the priority groupings
-    for (
-      let i = firstIntervalPosition;
-      i < scrollableCanvasWidth;
-      i += intervalSize
-    ) {
-      if (i > 0) {
-        const markerTimestamp = positionToTimestamp(
-          i + LABEL_FIXED_WIDTH,
-          state,
-        );
-        const markerLabel = Math.round(markerTimestamp);
-
-        const x = LABEL_FIXED_WIDTH + i;
-
-        context.fillStyle = COLORS.PRIORITY_BORDER;
-        context.fillRect(
-          x,
-          MARKER_HEIGHT - MARKER_TICK_HEIGHT,
-          REACT_PRIORITY_BORDER_SIZE,
-          MARKER_TICK_HEIGHT,
-        );
-
-        context.fillStyle = COLORS.TIME_MARKER_LABEL;
-        context.textAlign = 'right';
-        context.textBaseline = 'middle';
-        context.font = `${MARKER_FONT_SIZE}px sans-serif`;
-        context.fillText(
-          `${markerLabel}ms`,
-          x - MARKER_TEXT_PADDING,
-          MARKER_HEIGHT / 2,
-        );
-      }
-    }
+    renderAxisMarkers(context, state, canvasWidth, offsetX, zoomLevel);
   },
 );

--- a/src/types.js
+++ b/src/types.js
@@ -79,7 +79,7 @@ export type ReactHoverContextInfo = {|
   /** @deprecated */
   priorityIndex: number | null,
   /** @deprecated */
-  data: ReactProfilerData | null,
+  data: $ReadOnly<ReactProfilerData> | null,
   flamechartNode: FlamechartFrame | null,
 |};
 

--- a/src/util/usePanAndZoom.js
+++ b/src/util/usePanAndZoom.js
@@ -46,23 +46,32 @@ const initialState: PanAndZoomState = {
 };
 
 // TODO Account for fixed label width
-export function positionToTimestamp(position: number, state: PanAndZoomState) {
+export function positionToTimestamp(
+  position: number,
+  state: $ReadOnly<PanAndZoomState>,
+) {
   return (position - state.fixedColumnWidth + state.offsetX) / state.zoomLevel;
 }
 
 // TODO Account for fixed label width
-export function timestampToPosition(timestamp: number, state: PanAndZoomState) {
+export function timestampToPosition(
+  timestamp: number,
+  state: $ReadOnly<PanAndZoomState>,
+) {
   return timestamp * state.zoomLevel + state.fixedColumnWidth - state.offsetX;
 }
 
-export function durationToWidth(duration: number, state: PanAndZoomState) {
+export function durationToWidth(
+  duration: number,
+  state: $ReadOnly<PanAndZoomState>,
+) {
   return Math.max(
     duration * state.zoomLevel - BAR_HORIZONTAL_SPACING,
     MIN_BAR_WIDTH,
   );
 }
 
-function getMaxOffsetX(state: PanAndZoomState) {
+function getMaxOffsetX(state: $ReadOnly<PanAndZoomState>) {
   return (
     state.unscaledContentWidth * state.zoomLevel -
     state.canvasWidth +
@@ -70,7 +79,7 @@ function getMaxOffsetX(state: PanAndZoomState) {
   );
 }
 
-function getMaxOffsetY(state: PanAndZoomState) {
+function getMaxOffsetY(state: $ReadOnly<PanAndZoomState>) {
   return (
     state.unscaledContentHeight - state.canvasHeight + state.fixedHeaderHeight
   );
@@ -78,7 +87,7 @@ function getMaxOffsetY(state: PanAndZoomState) {
 
 type InitializeAction = {|
   type: 'initialize',
-  payload: $Shape<State>,
+  payload: $Shape<PanAndZoomState>,
 |};
 type MouseDownAction = {|
   type: 'mouse-down',
@@ -133,7 +142,7 @@ function reducer(
         zoomLevel: payload.zoomLevel,
         offsetX: clamp(0, getMaxOffsetX(state), state.offsetX),
         offsetY: clamp(0, getMaxOffsetY(state), state.offsetY),
-      }: State);
+      }: PanAndZoomState);
     }
     case 'mouse-down': {
       return {
@@ -199,7 +208,7 @@ function reducer(
           if (absDeltaY > ZOOM_WHEEL_DELTA_THRESHOLD) {
             const {canvasMouseX} = getCanvasMousePos(canvas, event);
 
-            const nextState = {
+            const nextState: PanAndZoomState = {
               ...state,
               zoomLevel: clamp(
                 minZoomLevel,


### PR DESCRIPTION
## Context

The current `renderCanvas` is too big to grasp, and it is difficult to work on it without a fear of accidentally breaking something.

This PR should speed up our development and to enable us to work independently on the canvas code.

Closes https://github.com/MLH-Fellowship/scheduling-profiler-prototype/issues/26.

## Design Details

The new broken `render*` functions are intended to be completely independent of each other, and only dependent on the parameters that are passed in. Ideally, `renderCanvas` will pass each render function a window to paint in. This will allow us to iterate on and change any render function without breaking any of the others.

However, this PR does not achieve that goal completely:

* Some of the current `render*` functions still independently offset themselves in the X direction: instead of being told the window to paint in, they may either just paint from the left edge (most `render*` functions), or offset based on a global constant (`renderAxisMarkers` automatically assumes that there are priority labels). I think this is still tolerable as our final design will remove the priority labels and always paint from left to right edges of the canvas.
* There are some assumptions of render ordering. I think this is unavoidable as we are currently painting in layers, but we'll need to keep this in mind.

## Summary of Changes

There are no logic changes, just code reshuffling and some variable renaming, so it should be easy-ish to review.

1. Break `renderCanvas` into smaller `render*` functions.
1. Change some of the original rendering code to take in a `canvasStartY` value instead of computing the Y value themselves from global constants and other `renderCanvas` variables.
1. Rename `renderReact` -> `renderSingleReactMarkOrMeasure` for greater clarity and to differentiate it from the new `renderReactMarksAndMeasures`.
1. Wrap some object types in the `$ReadOnly` util to ensure that the `render*` functions do not modify the data passed to it.

## Test Plan

1. Poke the web app, still works fine with all its bugs.
1. CI