### PR TITLE
Add minor EventTooltip improvements

### DIFF
--- a/src/EventTooltip.js
+++ b/src/EventTooltip.js
@@ -23,6 +23,14 @@ type Props = {|
   state: PanAndZoomState,
 |};
 
+function formatTimestamp(ms) {
+  return ms.toLocaleString(undefined, {minimumFractionDigits: 2}) + 'ms';
+}
+
+function formatDuration(ms) {
+  return prettyMilliseconds(ms, {millisecondsDecimalDigits: 3});
+}
+
 export default function EventTooltip({data, hoveredEvent, state}: Props) {
   const {canvasMouseY, canvasMouseX} = state;
 
@@ -132,11 +140,24 @@ const TooltipFlamechartNode = ({
         color: COLORS.TOOLTIP,
       }}
       ref={tooltipRef}>
-      {prettyMilliseconds((end - start) / 1000)} {name}
+      {formatDuration((end - start) / 1000)} {name}
       <div className={styles.DetailsGrid}>
-        <div className={styles.DetailsGridLabel}>Script URL:</div> {file}
-        <div className={styles.DetailsGridLabel}>Location:</div>
-        line {line}, column {col}
+        <div className={styles.DetailsGridLabel}>Timestamp:</div>
+        <div>{formatTimestamp(start / 1000)}</div>
+        {file && (
+          <>
+            <div className={styles.DetailsGridLabel}>Script URL:</div>
+            <div>{file}</div>
+          </>
+        )}
+        {(line !== undefined || col !== undefined) && (
+          <>
+            <div className={styles.DetailsGridLabel}>Location:</div>
+            <div>
+              line {line}, column {col}
+            </div>
+          </>
+        )}
       </div>
     </div>
   );
@@ -194,7 +215,7 @@ const TooltipReactEvent = ({
       <div className={styles.Divider} />
       <div className={styles.DetailsGrid}>
         <div className={styles.DetailsGridLabel}>Timestamp:</div>
-        {prettyMilliseconds(timestamp)}
+        <div>{formatTimestamp(timestamp)}</div>
         {componentStack && (
           <Fragment>
             <div className={styles.DetailsGridLabel}>Component stack:</div>
@@ -217,7 +238,7 @@ const TooltipReactMeasure = ({
   measure: ReactMeasure,
   tooltipRef: Return<typeof useRef>,
 }) => {
-  const {batchUID, duration, timestamp, type} = measure;
+  const {batchUID, duration, timestamp, type, lanes} = measure;
 
   let label = null;
   switch (type) {
@@ -251,13 +272,17 @@ const TooltipReactMeasure = ({
         color: COLORS.TOOLTIP,
       }}
       ref={tooltipRef}>
-      {prettyMilliseconds(duration)} {label}
+      {formatDuration(duration)} {label}
       <div className={styles.Divider} />
       <div className={styles.DetailsGrid}>
         <div className={styles.DetailsGridLabel}>Timestamp:</div>
-        {prettyMilliseconds(timestamp)}
+        <div>{formatTimestamp(timestamp)}</div>
         <div className={styles.DetailsGridLabel}>Batch duration:</div>
-        {prettyMilliseconds(stopTime - startTime)}
+        <div>{formatDuration(stopTime - startTime)}</div>
+        <div className={styles.DetailsGridLabel}>
+          Lane{lanes.length === 1 ? '' : 's'}:
+        </div>
+        <div>{lanes.join(', ')}</div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

Minor tooltip improvements that I made while working on #53.

## Differences

### Before

Timestamps >1s were formatted as seconds, which is not precise enough.
![image](https://user-images.githubusercontent.com/12784593/86886744-0aab3100-c12a-11ea-84ee-57a25fde48b1.png)

Durations had no decimal places, which is not precise enough. React measures also did not have lane information.
![image](https://user-images.githubusercontent.com/12784593/86886859-3c23fc80-c12a-11ea-976f-07a626724b56.png)

Flamegraph events did not have timestamps. Also, some flamegraph events had no script URL or location, which messed up the grid display.
![image](https://user-images.githubusercontent.com/12784593/86887122-ae94dc80-c12a-11ea-8bc3-f06c2e302246.png)


### After

Timestamps formatted as ms
![image](https://user-images.githubusercontent.com/12784593/86886833-2e6e7700-c12a-11ea-830e-a18b7f3e0798.png)

Durations have ns precision and React measures have lane information
![image](https://user-images.githubusercontent.com/12784593/86886890-46de9180-c12a-11ea-85dc-1a83108e9dc1.png)

Flamegraph events have timestamps, and empty script URLs and locations are hidden
![image](https://user-images.githubusercontent.com/12784593/86887093-a5a40b00-c12a-11ea-83d5-0eb3940dbb0a.png)
