### PR TITLE
Add basic README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,4 @@
+# Experimental React Concurrent Mode Profiler
+
+- Deployed at: https://react-scheduling-profiler.vercel.app
+- Context: https://github.com/MLH-Fellowship/0.4.x-projects/wiki/React-Concurrent-Mode-Profiler


### PR DESCRIPTION
The main goal is to trigger a Vercel deployment. I'll change the domain name of our deployment to the one in the README once it's deployed.