### PR TITLE
Fix tooltip bug, truncate componentName to use ellipsis

### DIFF
--- a/src/CanvasPage.css
+++ b/src/CanvasPage.css
@@ -4,4 +4,5 @@
   bottom: 0.5rem;
   left: 0.5rem;
   right: 0.5rem;
+  overflow: hidden;
 }

--- a/src/EventTooltip.css
+++ b/src/EventTooltip.css
@@ -28,12 +28,15 @@
 .DetailsGridLabel {
   color: #666;
   text-align: right;
-  white-space: nowrap;
+}
+
+.DetailsGridURL{
+  overflow: hidden;
 }
 
 .ComponentName {
   font-weight: bold;
-  white-space: nowrap;
+  word-wrap: break-word;
 }
 
 .ComponentStack {

--- a/src/EventTooltip.css
+++ b/src/EventTooltip.css
@@ -23,7 +23,6 @@
   padding-top: 5px;
   grid-gap: 2px 5px;
   grid-template-columns: min-content auto;
-  word-break: break-word;
 }
 
 .DetailsGridLabel {
@@ -32,11 +31,11 @@
   white-space: nowrap;
 }
 
-.Duration {
-}
-
 .ComponentName {
   font-weight: bold;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .ComponentStack {

--- a/src/EventTooltip.css
+++ b/src/EventTooltip.css
@@ -29,6 +29,7 @@
   color: #666;
   text-align: right;
   white-space: nowrap;
+  text-overflow: ellipsis;
 }
 
 .ComponentName {

--- a/src/EventTooltip.css
+++ b/src/EventTooltip.css
@@ -29,14 +29,11 @@
   color: #666;
   text-align: right;
   white-space: nowrap;
-  text-overflow: ellipsis;
 }
 
 .ComponentName {
   font-weight: bold;
   white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
 }
 
 .ComponentStack {

--- a/src/EventTooltip.js
+++ b/src/EventTooltip.js
@@ -32,17 +32,10 @@ function formatDuration(ms) {
 }
 
 function trimComponentName(name) {
-  if (name.length > 32) {
-    return name.substring(0, 31) + '...';
+  if (name.length > 128) {
+    return name.substring(0, 127) + '...';
   }
   return name;
-}
-
-function trimURL(label) {
-  if (label.length > 64) {
-    return label.substring(0, 63) + '...';
-  }
-  return label;
 }
 
 export default function EventTooltip({data, hoveredEvent, state}: Props) {
@@ -161,7 +154,7 @@ const TooltipFlamechartNode = ({
         {file && (
           <>
             <div className={styles.DetailsGridLabel}>Script URL:</div>
-            <div>{trimURL(file)}</div>
+            <div className={styles.DetailsGridURL}>{file}</div>
           </>
         )}
         {(line !== undefined || col !== undefined) && (

--- a/src/EventTooltip.js
+++ b/src/EventTooltip.js
@@ -31,6 +31,20 @@ function formatDuration(ms) {
   return prettyMilliseconds(ms, {millisecondsDecimalDigits: 3});
 }
 
+function trimComponentName(name) {
+  if (name.length > 32) {
+    return name.substring(0, 31) + '...';
+  }
+  return name;
+}
+
+function trimURL(label) {
+  if (label.length > 64) {
+    return label.substring(0, 63) + '...';
+  }
+  return label;
+}
+
 export default function EventTooltip({data, hoveredEvent, state}: Props) {
   const {canvasMouseY, canvasMouseX} = state;
 
@@ -140,14 +154,14 @@ const TooltipFlamechartNode = ({
         color: COLORS.TOOLTIP,
       }}
       ref={tooltipRef}>
-      {formatDuration((end - start) / 1000)} {name}
+      {formatDuration((end - start) / 1000)} {trimComponentName(name)}
       <div className={styles.DetailsGrid}>
         <div className={styles.DetailsGridLabel}>Timestamp:</div>
         <div>{formatTimestamp(start / 1000)}</div>
         {file && (
           <>
             <div className={styles.DetailsGridLabel}>Script URL:</div>
-            <div>{file}</div>
+            <div>{trimURL(file)}</div>
           </>
         )}
         {(line !== undefined || col !== undefined) && (
@@ -208,7 +222,7 @@ const TooltipReactEvent = ({
       ref={tooltipRef}>
       {componentName && (
         <span className={styles.ComponentName} style={{color}}>
-          {componentName}
+          {trimComponentName(componentName)}
         </span>
       )}{' '}
       {label}


### PR DESCRIPTION
Resolves #47 and also closes #67 

This PR fixes the canvas reset issue when the tooltips would overflow the CanvasPage (checkout issue for more context). 

The solution to allow overflow on CanvasPage was something of a hunch that made sense and worked. The root cause I think was an edge case of the eventTooltip div overflowing the current div with no room left for the tooltip to reduce to. (Doesn't make much sense describing as text, I discussed this internally with @taneliang to explain better).

Removed empty class `Duration`.

This PR also truncates long component names with ellipsis.
(Not tested yet, ideally should work. Will mark it ready for review as soon as I can test it with suitable data) 