### PR TITLE
Fix Flow large memory usage

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -11,5 +11,8 @@
 [lints]
 
 [options]
+module.file_ext=.js
+module.file_ext=.mjs
+module.file_ext=.cjs
 
 [strict]


### PR DESCRIPTION
Fix Flow's crazy memory usage by disabling JSON file type checking.

Test Plan: VS Code's Flow extension actually starts