### PR TITLE
Remove link to a private internal repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
 # Experimental React Concurrent Mode Profiler
 
 - Deployed at: https://react-scheduling-profiler.vercel.app
-- Context: https://github.com/MLH-Fellowship/0.4.x-projects/wiki/React-Concurrent-Mode-Profiler


### PR DESCRIPTION
Removed the link to a private repo containing information about all the other MLH projects. 
It's also inaccessible to everyone other than the authorized members so doesn't make much sense to have a link to it.