### PR TITLE
[Optimize flamechart][2/4] Replace Speedscope types with custom stack frame type

### DIFF
--- a/src/CanvasPage.js
+++ b/src/CanvasPage.js
@@ -191,7 +191,7 @@ function AutoSizedCanvas({data, height, width}: AutoSizedCanvasProps) {
         hoveredEvent &&
         (hoveredEvent.event ||
           hoveredEvent.measure ||
-          hoveredEvent.flamechartNode)
+          hoveredEvent.flamechartStackFrame)
       ) {
         setMouseLocation({
           x: interaction.payload.event.x,
@@ -226,7 +226,7 @@ function AutoSizedCanvas({data, height, width}: AutoSizedCanvasProps) {
         if (!hoveredEvent || hoveredEvent.event !== event) {
           setHoveredEvent({
             event,
-            flamechartNode: null,
+            flamechartStackFrame: null,
             measure: null,
             data,
           });
@@ -240,7 +240,7 @@ function AutoSizedCanvas({data, height, width}: AutoSizedCanvasProps) {
         if (!hoveredEvent || hoveredEvent.measure !== measure) {
           setHoveredEvent({
             event: null,
-            flamechartNode: null,
+            flamechartStackFrame: null,
             measure,
             data,
           });
@@ -250,11 +250,14 @@ function AutoSizedCanvas({data, height, width}: AutoSizedCanvasProps) {
 
     const {current: flamegraphView} = flamegraphViewRef;
     if (flamegraphView) {
-      flamegraphView.onHover = flamechartNode => {
-        if (!hoveredEvent || hoveredEvent.flamechartNode !== flamechartNode) {
+      flamegraphView.onHover = flamechartStackFrame => {
+        if (
+          !hoveredEvent ||
+          hoveredEvent.flamechartStackFrame !== flamechartStackFrame
+        ) {
           setHoveredEvent({
             event: null,
-            flamechartNode,
+            flamechartStackFrame,
             measure: null,
             data,
           });
@@ -285,7 +288,7 @@ function AutoSizedCanvas({data, height, width}: AutoSizedCanvasProps) {
     const {current: flamegraphView} = flamegraphViewRef;
     if (flamegraphView) {
       flamegraphView.setHoveredFlamechartNode(
-        hoveredEvent ? hoveredEvent.flamechartNode : null,
+        hoveredEvent ? hoveredEvent.flamechartStackFrame : null,
       );
     }
   }, [
@@ -311,7 +314,11 @@ function AutoSizedCanvas({data, height, width}: AutoSizedCanvasProps) {
           if (contextData.hoveredEvent == null) {
             return null;
           }
-          const {event, flamechartNode, measure} = contextData.hoveredEvent;
+          const {
+            event,
+            flamechartStackFrame,
+            measure,
+          } = contextData.hoveredEvent;
           return (
             <Fragment>
               {event !== null && (
@@ -342,19 +349,20 @@ function AutoSizedCanvas({data, height, width}: AutoSizedCanvasProps) {
                   Copy summary
                 </ContextMenuItem>
               )}
-              {flamechartNode !== null && (
+              {flamechartStackFrame !== null && (
                 <ContextMenuItem
-                  onClick={() => copy(flamechartNode.node.frame.file)}
+                  onClick={() => copy(flamechartStackFrame.scriptUrl)}
                   title="Copy file path">
                   Copy file path
                 </ContextMenuItem>
               )}
-              {flamechartNode !== null && (
+              {flamechartStackFrame !== null && (
                 <ContextMenuItem
                   onClick={() =>
                     copy(
-                      `line ${flamechartNode.node.frame.line ||
-                        ''}, column ${flamechartNode.node.frame.col || ''}`,
+                      `line ${flamechartStackFrame.locationLine ||
+                        ''}, column ${flamechartStackFrame.locationColumn ||
+                        ''}`,
                     )
                   }
                   title="Copy location">

--- a/src/EventTooltip.js
+++ b/src/EventTooltip.js
@@ -1,8 +1,8 @@
 // @flow
 
 import type {Point} from './layout';
-import type {FlamechartFrame} from '@elg/speedscope';
 import type {
+  FlamechartStackFrame,
   ReactEvent,
   ReactMeasure,
   ReactProfilerData,
@@ -48,7 +48,7 @@ export default function EventTooltip({data, hoveredEvent, origin}: Props) {
     return null;
   }
 
-  const {event, flamechartNode, measure} = hoveredEvent;
+  const {event, flamechartStackFrame, measure} = hoveredEvent;
 
   if (event !== null) {
     switch (event.type) {
@@ -107,10 +107,10 @@ export default function EventTooltip({data, hoveredEvent, origin}: Props) {
         console.warn(`Unexpected measure type "${measure.type}"`);
         break;
     }
-  } else if (flamechartNode !== null) {
+  } else if (flamechartStackFrame !== null) {
     return (
       <TooltipFlamechartNode
-        flamechartNode={flamechartNode}
+        stackFrame={flamechartStackFrame}
         tooltipRef={tooltipRef}
       />
     );
@@ -129,14 +129,20 @@ function formatComponentStack(componentStack: string): string {
 }
 
 const TooltipFlamechartNode = ({
-  flamechartNode,
+  stackFrame,
   tooltipRef,
 }: {
-  flamechartNode: FlamechartFrame,
+  stackFrame: FlamechartStackFrame,
   tooltipRef: Return<typeof useRef>,
 }) => {
-  const {end, node, start} = flamechartNode;
-  const {col, file, line, name} = node.frame;
+  const {
+    name,
+    timestamp,
+    duration,
+    scriptUrl,
+    locationLine,
+    locationColumn,
+  } = stackFrame;
   return (
     <div
       className={styles.Tooltip}
@@ -145,21 +151,21 @@ const TooltipFlamechartNode = ({
         color: COLORS.TOOLTIP,
       }}
       ref={tooltipRef}>
-      {formatDuration((end - start) / 1000)} {trimComponentName(name)}
+      {formatDuration(duration)} {trimComponentName(name)}
       <div className={styles.DetailsGrid}>
         <div className={styles.DetailsGridLabel}>Timestamp:</div>
-        <div>{formatTimestamp(start / 1000)}</div>
-        {file && (
+        <div>{formatTimestamp(timestamp)}</div>
+        {scriptUrl && (
           <>
             <div className={styles.DetailsGridLabel}>Script URL:</div>
-            <div className={styles.DetailsGridURL}>{file}</div>
+            <div className={styles.DetailsGridURL}>{scriptUrl}</div>
           </>
         )}
-        {(line !== undefined || col !== undefined) && (
+        {(locationLine !== undefined || locationColumn !== undefined) && (
           <>
             <div className={styles.DetailsGridLabel}>Location:</div>
             <div>
-              line {line}, column {col}
+              line {locationLine}, column {locationColumn}
             </div>
           </>
         )}

--- a/src/types.js
+++ b/src/types.js
@@ -1,7 +1,5 @@
 // @flow
 
-import type {Flamechart, FlamechartFrame} from '@elg/speedscope';
-
 // Type utilities
 
 // Source: https://github.com/facebook/flow/issues/4002#issuecomment-323612798
@@ -87,19 +85,37 @@ export type ReactMeasure = {|
   +depth: number,
 |};
 
-export type FlamechartData = Flamechart;
+/**
+ * A flamechart stack frame belonging to a stack trace.
+ */
+export type FlamechartStackFrame = {|
+  name: string,
+  timestamp: Milliseconds,
+  duration: Milliseconds,
+  scriptUrl?: string,
+  locationLine?: number,
+  locationColumn?: number,
+|};
+
+/**
+ * A "layer" of stack frames in the profiler UI, i.e. all stack frames of the
+ * same depth across all stack traces. Displayed as a flamechart row in the UI.
+ */
+export type FlamechartStackLayer = FlamechartStackFrame[];
+
+export type Flamechart = FlamechartStackLayer[];
 
 export type ReactProfilerData = {|
   startTime: number,
   duration: number,
   events: ReactEvent[],
   measures: ReactMeasure[],
-  flamechart: FlamechartData,
+  flamechart: Flamechart,
 |};
 
 export type ReactHoverContextInfo = {|
   event: ReactEvent | null,
   measure: ReactMeasure | null,
   data: $ReadOnly<ReactProfilerData> | null,
-  flamechartNode: FlamechartFrame | null,
+  flamechartStackFrame: FlamechartStackFrame | null,
 |};

--- a/src/util/__tests__/__snapshots__/preprocessData-test.js.snap
+++ b/src/util/__tests__/__snapshots__/preprocessData-test.js.snap
@@ -573,17 +573,7 @@ Object {
       "type": "suspense-resolved",
     },
   ],
-  "flamechart": Flamechart {
-    "layers": Array [],
-    "minFrameWidth": 1,
-    "source": Object {
-      "forEachCall": [Function],
-      "formatValue": [Function],
-      "getColorBucketForFrame": [Function],
-      "getTotalWeight": [Function],
-    },
-    "totalWeight": -8993778496,
-  },
+  "flamechart": Array [],
   "measures": Array [
     Object {
       "batchUID": 0,
@@ -1287,17 +1277,7 @@ Object {
       "type": "schedule-force-update",
     },
   ],
-  "flamechart": Flamechart {
-    "layers": Array [],
-    "minFrameWidth": 1,
-    "source": Object {
-      "forEachCall": [Function],
-      "formatValue": [Function],
-      "getColorBucketForFrame": [Function],
-      "getTotalWeight": [Function],
-    },
-    "totalWeight": -40806924876,
-  },
+  "flamechart": Array [],
   "measures": Array [
     Object {
       "batchUID": 0,

--- a/src/util/__tests__/preprocessData-test.js
+++ b/src/util/__tests__/preprocessData-test.js
@@ -75,13 +75,12 @@ describe(preprocessData, () => {
         {"pid":57632,"tid":38659,"ts":874860756224,"ph":"X","cat":"disabled-by-default-devtools.timeline","name":"RunTask","dur":7,"tdur":6,"tts":8700285008,"args":{}},
         {"pid":57632,"tid":38659,"ts":874860756233,"ph":"X","cat":"disabled-by-default-devtools.timeline","name":"RunTask","dur":5,"tdur":4,"tts":8700285017,"args":{}},
       ]),
-    ).toMatchObject({
+    ).toEqual({
       startTime: 8993778496,
       duration: 865866977.737,
       events: [],
       measures: [],
-      // TODO: Change expectation back to toEqual and test for empty flamechart
-      // when custom flamechart type is added.
+      flamechart: [],
     });
   });
 
@@ -325,4 +324,6 @@ describe(preprocessData, () => {
       ]),
     ).toMatchSnapshot();
   });
+
+  // TODO: Add test for flamechart parsing
 });


### PR DESCRIPTION
Stack PR by [STACK ATTACK](https://github.com/taneliang/stack-attack):
- #89 Fix lint failure from #88
- #90 [Optimize flamechart][1/4] Add flamechart to ReactProfilerData
- **#91 [Optimize flamechart][2/4] Replace Speedscope types with custom stack frame type**
- #92 [Optimize flamechart][3/4] Rename flame graph -> flame chart
- #93 [Optimize flamechart][4/4] Split FlamechartView into row views

### Summary

Lays groundwork for #75 by reducing the flamechart data passed around
the app.

Was also intended to help #50 by moving some division operations from
the hot render loops into preprocessFlamechart, but any performance
gains are negligible.

### Test Plan

* `yarn flow`: no errors in modified code
* `yarn lint`
* `yarn start`: no performance difference
* `yarn test`: tests updated and passing