### PR TITLE
[Optimize flamechart][4/4] Split FlamechartView into row views

### DIFF
--- a/src/CanvasPage.js
+++ b/src/CanvasPage.js
@@ -140,14 +140,13 @@ function AutoSizedCanvas({data, height, width}: AutoSizedCanvasProps) {
       surfaceRef.current,
       {origin: zeroPoint, size: {width, height}},
       data.flamechart,
-      data,
+      data.duration,
     );
     flamechartViewRef.current = flamechartView;
     const flamechartVScrollWrapper = new VerticalScrollView(
       surfaceRef.current,
       {origin: zeroPoint, size: {width, height}},
       flamechartView,
-      flamechartView.intrinsicSize.height,
     );
 
     const stackedZoomables = new StaticLayoutView(
@@ -166,7 +165,7 @@ function AutoSizedCanvas({data, height, width}: AutoSizedCanvasProps) {
       surfaceRef.current,
       {origin: zeroPoint, size: {width, height}},
       stackedZoomables,
-      flamechartView.intrinsicSize.width,
+      reactEventsView.intrinsicSize.width,
     );
 
     rootViewRef.current = new StaticLayoutView(
@@ -250,7 +249,7 @@ function AutoSizedCanvas({data, height, width}: AutoSizedCanvasProps) {
 
     const {current: flamechartView} = flamechartViewRef;
     if (flamechartView) {
-      flamechartView.onHover = flamechartStackFrame => {
+      flamechartView.setOnHover(flamechartStackFrame => {
         if (
           !hoveredEvent ||
           hoveredEvent.flamechartStackFrame !== flamechartStackFrame
@@ -262,7 +261,7 @@ function AutoSizedCanvas({data, height, width}: AutoSizedCanvasProps) {
             data,
           });
         }
-      };
+      });
     }
   }, [
     reactEventsViewRef,
@@ -287,7 +286,7 @@ function AutoSizedCanvas({data, height, width}: AutoSizedCanvasProps) {
 
     const {current: flamechartView} = flamechartViewRef;
     if (flamechartView) {
-      flamechartView.setHoveredFlamechartNode(
+      flamechartView.setHoveredFlamechartStackFrame(
         hoveredEvent ? hoveredEvent.flamechartStackFrame : null,
       );
     }

--- a/src/layout/ColorView.js
+++ b/src/layout/ColorView.js
@@ -1,0 +1,29 @@
+// @flow
+
+import type {Rect} from './geometry';
+
+import {Surface} from './Surface';
+import {View} from './View';
+
+/**
+ * View that fills its visible area with a CSS color.
+ */
+export class ColorView extends View {
+  _color: string;
+
+  constructor(surface: Surface, frame: Rect, color: string) {
+    super(surface, frame);
+    this._color = color;
+  }
+
+  draw(context: CanvasRenderingContext2D) {
+    const {_color, visibleArea} = this;
+    context.fillStyle = _color;
+    context.fillRect(
+      visibleArea.origin.x,
+      visibleArea.origin.y,
+      visibleArea.size.width,
+      visibleArea.size.height,
+    );
+  }
+}

--- a/src/layout/StaticLayoutView.js
+++ b/src/layout/StaticLayoutView.js
@@ -18,13 +18,17 @@ export const layeredLayout: Layouter = (views, frame) =>
     subview.setFrame(frame);
   });
 
+/**
+ * Stacks `views` vertically in `frame`. All views in `views` will have their
+ * widths set to the frame's width.
+ */
 export const verticallyStackedLayout: Layouter = (views, frame) => {
   let currentY = frame.origin.y;
   views.forEach(view => {
     const desiredSize = view.desiredSize();
     const height = desiredSize
       ? desiredSize.height
-      : frame.size.height - currentY;
+      : frame.origin.y + frame.size.height - currentY;
     const proposedFrame = {
       origin: {x: frame.origin.x, y: currentY},
       size: {width: frame.size.width, height},

--- a/src/layout/VerticalScrollView.js
+++ b/src/layout/VerticalScrollView.js
@@ -37,7 +37,6 @@ function clamp(min: number, max: number, value: number): number {
 
 export class VerticalScrollView extends View {
   contentView: View;
-  intrinsicContentHeight: number;
 
   scrollState: VerticalScrollState = {
     offsetY: 0,
@@ -52,14 +51,12 @@ export class VerticalScrollView extends View {
     surface: Surface,
     frame: Rect,
     contentView: View,
-    intrinsicContentHeight: number,
     stateDeriver?: (state: VerticalScrollState) => VerticalScrollState,
     onStateChange?: (state: VerticalScrollState) => void,
   ) {
     super(surface, frame);
     this.contentView = contentView;
     contentView.superview = this;
-    this.intrinsicContentHeight = intrinsicContentHeight;
     if (stateDeriver) this.stateDeriver = stateDeriver;
     if (onStateChange) this.onStateChange = onStateChange;
   }
@@ -78,6 +75,13 @@ export class VerticalScrollView extends View {
 
   layoutSubviews() {
     const {offsetY} = this.scrollState;
+    const desiredSize = this.contentView.desiredSize();
+
+    const remainingHeight = this.frame.size.height;
+    const desiredHeight = desiredSize ? desiredSize.height : 0;
+    // Force last view to take up at least all remaining vertical space.
+    const height = Math.max(desiredHeight, remainingHeight);
+
     const proposedFrame = {
       origin: {
         x: this.frame.origin.x,
@@ -85,7 +89,7 @@ export class VerticalScrollView extends View {
       },
       size: {
         width: this.frame.size.width,
-        height: this.intrinsicContentHeight,
+        height,
       },
     };
     this.contentView.setFrame(proposedFrame);

--- a/src/layout/index.js
+++ b/src/layout/index.js
@@ -1,6 +1,7 @@
 // @flow
 
 export * from './geometry';
+export * from './ColorView';
 export * from './HorizontalPanAndZoomView';
 export * from './StaticLayoutView';
 export * from './Surface';


### PR DESCRIPTION
Stack PR by [STACK ATTACK](https://github.com/taneliang/stack-attack):
- #89 Fix lint failure from #88
- #90 [Optimize flamechart][1/4] Add flamechart to ReactProfilerData
- #91 [Optimize flamechart][2/4] Replace Speedscope types with custom stack frame type
- #92 [Optimize flamechart][3/4] Rename flame graph -> flame chart
- **#93 [Optimize flamechart][4/4] Split FlamechartView into row views**

### Summary

Allow the view system to render only affected flamechart rows. This
greatly improves flamechart hover performance, which has a high impact
on our app's performance as the flamechart is the slowest view to
render.

Also adds a new `ColorView` view that fills the flamechart area with a
solid background color to fix these issues:

1. Black empty areas appearing below flamecharts without much stack
   depth
2. Lines appearing between flamechart rows. My hypothesis is that these
   are appearing due to subpixel rendering, even though the flamechart
   rows' `visibleArea`s are all integers.

Related to #50.

### Test Plan

* `yarn flow`: no errors in changed code
* `yarn lint`
* `yarn start`: 60 FPS hovers on our Facebook.com profile
* `yarn test`