### PR TITLE
Fix tests

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,8 +1,0 @@
-{
-  "presets": [
-    [
-      "react-app",
-      { "absoluteRuntime": false, "flow": true, "typescript": false }
-    ]
-  ]
-}

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  presets: [
+    ['react-app', {absoluteRuntime: false, flow: true, typescript: false}],
+  ],
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,4 +2,8 @@ module.exports = {
   moduleNameMapper: {
     '\\.css$': 'identity-obj-proxy',
   },
+  transformIgnorePatterns: [
+    // Pass @elg/speedscope through transforms
+    '/node_modules/(?!@elg/speedscope).+\\.js$',
+  ],
 };

--- a/src/util/__tests__/__snapshots__/preprocessData-test.js.snap
+++ b/src/util/__tests__/__snapshots__/preprocessData-test.js.snap
@@ -573,6 +573,17 @@ Object {
       "type": "suspense-resolved",
     },
   ],
+  "flamechart": Flamechart {
+    "layers": Array [],
+    "minFrameWidth": 1,
+    "source": Object {
+      "forEachCall": [Function],
+      "formatValue": [Function],
+      "getColorBucketForFrame": [Function],
+      "getTotalWeight": [Function],
+    },
+    "totalWeight": -8993778496,
+  },
   "measures": Array [
     Object {
       "batchUID": 0,
@@ -1276,6 +1287,17 @@ Object {
       "type": "schedule-force-update",
     },
   ],
+  "flamechart": Flamechart {
+    "layers": Array [],
+    "minFrameWidth": 1,
+    "source": Object {
+      "forEachCall": [Function],
+      "formatValue": [Function],
+      "getColorBucketForFrame": [Function],
+      "getTotalWeight": [Function],
+    },
+    "totalWeight": -40806924876,
+  },
   "measures": Array [
     Object {
       "batchUID": 0,

--- a/src/util/__tests__/preprocessData-test.js
+++ b/src/util/__tests__/preprocessData-test.js
@@ -50,27 +50,17 @@ describe(getLanesFromTransportDecimalBitmask, () => {
 });
 
 describe(preprocessData, () => {
-  it('should return empty data given an empty timeline', () => {
-    expect(preprocessData([])).toEqual({
-      startTime: 0,
-      duration: 0,
-      events: [],
-      measures: [],
-    });
+  it('should throw given an empty timeline', () => {
+    expect(() => preprocessData([])).toThrow();
   });
 
-  it('should return empty data given a timeline with no Profile event', () => {
-    expect(
+  it('should throw given a timeline with no Profile event', () => {
+    expect(() =>
       // prettier-ignore
       preprocessData([
         {"args":{"data":{"navigationId":"43BC238A4FB7548146D3CD739C9C9434"}},"cat":"blink.user_timing","name":"--schedule-render-512-","ph":"R","pid":9312,"tid":10252,"ts":8994056569,"tts":1816966},
       ]),
-    ).toEqual({
-      startTime: 0,
-      duration: 0,
-      events: [],
-      measures: [],
-    });
+    ).toThrow();
   });
 
   it('should return empty data given a timeline with no React scheduling profiling marks', () => {
@@ -85,11 +75,13 @@ describe(preprocessData, () => {
         {"pid":57632,"tid":38659,"ts":874860756224,"ph":"X","cat":"disabled-by-default-devtools.timeline","name":"RunTask","dur":7,"tdur":6,"tts":8700285008,"args":{}},
         {"pid":57632,"tid":38659,"ts":874860756233,"ph":"X","cat":"disabled-by-default-devtools.timeline","name":"RunTask","dur":5,"tdur":4,"tts":8700285017,"args":{}},
       ]),
-    ).toEqual({
+    ).toMatchObject({
       startTime: 8993778496,
       duration: 865866977.737,
       events: [],
       measures: [],
+      // TODO: Change expectation back to toEqual and test for empty flamechart
+      // when custom flamechart type is added.
     });
   });
 


### PR DESCRIPTION
### Summary

#90 broke tests on master. Problems:

1. Jest could not deal with `export` in code imported from node_modules/@elg/speedscope. Changed our Babel and Jest configs to fix this following https://github.com/facebook/jest/issues/6229#issuecomment-403539460
1. `preprocessData` tests were not updated. This PR updates them, with some TODOs to be done in the remaining PRs in the stack based on #90.

### Test Plan

* CI (`yarn lint`, `yarn test`)
* `yarn flow`: no change in errors