### PR TITLE
[Improve base View][1/n] Add subview handling to View

### DIFF
--- a/src/canvas/views/FlamechartView.js
+++ b/src/canvas/views/FlamechartView.js
@@ -244,7 +244,7 @@ class FlamechartStackLayerView extends View {
     onHover(null);
   }
 
-  handleInteractionAndPropagateToSubviews(interaction: Interaction) {
+  handleInteraction(interaction: Interaction) {
     switch (interaction.type) {
       case 'hover':
         this.handleHover(interaction);
@@ -295,7 +295,7 @@ export class FlamechartView extends View {
       colorView,
       this.verticalStackView,
     ]);
-    this.layerStackView.superview = this;
+    this.addSubview(this.layerStackView);
   }
 
   desiredSize() {
@@ -314,11 +314,6 @@ export class FlamechartView extends View {
   setOnHover(onHover: (node: FlamechartStackFrame | null) => void) {
     this.onHover = onHover;
     this.flamechartRowViews.forEach(rowView => (rowView.onHover = onHover));
-  }
-
-  setNeedsDisplay() {
-    super.setNeedsDisplay();
-    this.layerStackView.setNeedsDisplay();
   }
 
   layoutSubviews() {
@@ -344,10 +339,6 @@ export class FlamechartView extends View {
     layerStackView.setVisibleArea(this.visibleArea);
   }
 
-  draw(context: CanvasRenderingContext2D) {
-    this.layerStackView.displayIfNeeded(context);
-  }
-
   /**
    * @private
    */
@@ -364,12 +355,11 @@ export class FlamechartView extends View {
     }
   }
 
-  handleInteractionAndPropagateToSubviews(interaction: Interaction) {
+  handleInteraction(interaction: Interaction) {
     switch (interaction.type) {
       case 'hover':
         this.handleHover(interaction);
         break;
     }
-    this.layerStackView.handleInteractionAndPropagateToSubviews(interaction);
   }
 }

--- a/src/canvas/views/ReactEventsView.js
+++ b/src/canvas/views/ReactEventsView.js
@@ -236,7 +236,7 @@ export class ReactEventsView extends View {
     onHover(null);
   }
 
-  handleInteractionAndPropagateToSubviews(interaction: Interaction) {
+  handleInteraction(interaction: Interaction) {
     switch (interaction.type) {
       case 'hover':
         this.handleHover(interaction);

--- a/src/canvas/views/ReactMeasuresView.js
+++ b/src/canvas/views/ReactMeasuresView.js
@@ -294,7 +294,7 @@ export class ReactMeasuresView extends View {
     onHover(null);
   }
 
-  handleInteractionAndPropagateToSubviews(interaction: Interaction) {
+  handleInteraction(interaction: Interaction) {
     switch (interaction.type) {
       case 'hover':
         this.handleHover(interaction);

--- a/src/layout/HorizontalPanAndZoomView.js
+++ b/src/layout/HorizontalPanAndZoomView.js
@@ -53,6 +53,10 @@ function zoomLevelAndIntrinsicWidthToFrameWidth(
 }
 
 export class HorizontalPanAndZoomView extends View {
+  /**
+   * Reference to the content view. This view is also the only view in
+   * `this.subviews`.
+   */
   contentView: View;
   intrinsicContentWidth: number;
 
@@ -79,15 +83,10 @@ export class HorizontalPanAndZoomView extends View {
   ) {
     super(surface, frame);
     this.contentView = contentView;
-    contentView.superview = this;
+    this.addSubview(this.contentView);
     this.intrinsicContentWidth = intrinsicContentWidth;
     if (stateDeriver) this.stateDeriver = stateDeriver;
     if (onStateChange) this.onStateChange = onStateChange;
-  }
-
-  setNeedsDisplay() {
-    super.setNeedsDisplay();
-    this.contentView.setNeedsDisplay();
   }
 
   setFrame(newFrame: Rect) {
@@ -114,10 +113,6 @@ export class HorizontalPanAndZoomView extends View {
     };
     this.contentView.setFrame(proposedFrame);
     this.contentView.setVisibleArea(this.visibleArea);
-  }
-
-  draw(context: CanvasRenderingContext2D) {
-    this.contentView.displayIfNeeded(context);
   }
 
   isPanning = false;
@@ -214,7 +209,7 @@ export class HorizontalPanAndZoomView extends View {
     this.updateState(offsetAdjustedState);
   }
 
-  handleInteractionAndPropagateToSubviews(interaction: Interaction) {
+  handleInteraction(interaction: Interaction) {
     switch (interaction.type) {
       case 'horizontal-pan-start':
         this.handleHorizontalPanStart(interaction);
@@ -234,7 +229,6 @@ export class HorizontalPanAndZoomView extends View {
         this.handleWheelZoom(interaction);
         break;
     }
-    this.contentView.handleInteractionAndPropagateToSubviews(interaction);
   }
 
   /**

--- a/src/layout/StaticLayoutView.js
+++ b/src/layout/StaticLayoutView.js
@@ -1,6 +1,5 @@
 // @flow
 
-import type {Interaction} from '../useCanvasInteraction';
 import type {Rect} from './geometry';
 
 import {Surface} from './Surface';
@@ -39,28 +38,17 @@ export const verticallyStackedLayout: Layouter = (views, frame) => {
 };
 
 export class StaticLayoutView extends View {
-  subviews: View[] = [];
   layouter: Layouter;
 
   constructor(
     surface: Surface,
     frame: Rect,
     layouter: Layouter,
-    subviews: View[],
+    initialSubviews: View[],
   ) {
     super(surface, frame);
     this.layouter = layouter;
-    subviews.forEach(subview => this.addSubview(subview));
-  }
-
-  setNeedsDisplay() {
-    super.setNeedsDisplay();
-    this.subviews.forEach(subview => subview.setNeedsDisplay());
-  }
-
-  addSubview(view: View) {
-    this.subviews.push(view);
-    view.superview = this;
+    initialSubviews.forEach(subview => this.addSubview(subview));
   }
 
   layoutSubviews() {
@@ -75,20 +63,5 @@ export class StaticLayoutView extends View {
         subview.setVisibleArea(zeroRect);
       }
     });
-  }
-
-  draw(context: CanvasRenderingContext2D) {
-    const {subviews, visibleArea} = this;
-    subviews.forEach(subview => {
-      if (rectIntersectsRect(visibleArea, subview.visibleArea)) {
-        subview.displayIfNeeded(context);
-      }
-    });
-  }
-
-  handleInteractionAndPropagateToSubviews(interaction: Interaction) {
-    this.subviews.forEach(subview =>
-      subview.handleInteractionAndPropagateToSubviews(interaction),
-    );
   }
 }

--- a/src/layout/Surface.js
+++ b/src/layout/Surface.js
@@ -8,6 +8,10 @@ import {getCanvasContext} from '../canvas/canvasUtils';
 import {View} from './View';
 import {zeroPoint} from './geometry';
 
+/**
+ * Represents the canvas surface and a view heirarchy. A surface is also the
+ * place where all interactions enter the view heirarchy.
+ */
 export class Surface {
   rootView: ?View;
   context: ?CanvasRenderingContext2D;

--- a/src/layout/VerticalScrollView.js
+++ b/src/layout/VerticalScrollView.js
@@ -36,6 +36,10 @@ function clamp(min: number, max: number, value: number): number {
 }
 
 export class VerticalScrollView extends View {
+  /**
+   * Reference to the content view. This view is also the only view in
+   * `this.subviews`.
+   */
   contentView: View;
 
   scrollState: VerticalScrollState = {
@@ -56,14 +60,9 @@ export class VerticalScrollView extends View {
   ) {
     super(surface, frame);
     this.contentView = contentView;
-    contentView.superview = this;
+    this.addSubview(this.contentView);
     if (stateDeriver) this.stateDeriver = stateDeriver;
     if (onStateChange) this.onStateChange = onStateChange;
-  }
-
-  setNeedsDisplay() {
-    super.setNeedsDisplay();
-    this.contentView.setNeedsDisplay();
   }
 
   setFrame(newFrame: Rect) {
@@ -94,10 +93,6 @@ export class VerticalScrollView extends View {
     };
     this.contentView.setFrame(proposedFrame);
     this.contentView.setVisibleArea(this.visibleArea);
-  }
-
-  draw(context: CanvasRenderingContext2D) {
-    this.contentView.displayIfNeeded(context);
   }
 
   isPanning = false;
@@ -151,7 +146,7 @@ export class VerticalScrollView extends View {
     });
   }
 
-  handleInteractionAndPropagateToSubviews(interaction: Interaction) {
+  handleInteraction(interaction: Interaction) {
     switch (interaction.type) {
       case 'vertical-pan-start':
         this.handleVerticalPanStart(interaction);
@@ -166,7 +161,6 @@ export class VerticalScrollView extends View {
         this.handleWheelPlain(interaction);
         break;
     }
-    this.contentView.handleInteractionAndPropagateToSubviews(interaction);
   }
 
   /**


### PR DESCRIPTION
Stack PR by [STACK ATTACK](https://github.com/taneliang/stack-attack):
- **#99 [Improve base View][1/n] Add subview handling to View**
- #100 [Improve base View][2/n] Rationalize view layout system
- #101 [Improve base View][3/n] Add _ to views' private vars and methods
- #102 [Improve base View][4/n] Write tests for geometry.js

Stacked on #96.

Summary
--

This PR begins a stack of PRs that improves the base `View` class
implemented in #80.

This PR adds subview management to `View`, as there was a lot of
duplicated subview handling code present in almost all our `View`
subclasses. This also brings us closer to UIKit's `UIView`, which
also handles its own subviews.

Resolves #95.

Test Plan
--

* `yarn start`: nothing broken
* `yarn lint`
* `yarn flow`: no errors in affected code
* `yarn test`