### PR TITLE
[Improve base View][3/n] Add _ to views' private vars and methods

### DIFF
--- a/src/CanvasPage.js
+++ b/src/CanvasPage.js
@@ -163,7 +163,7 @@ function AutoSizedCanvas({data, height, width}: AutoSizedCanvasProps) {
       surfaceRef.current,
       {origin: zeroPoint, size: {width, height}},
       stackedZoomables,
-      reactEventsView.intrinsicSize.width,
+      data.duration,
     );
 
     rootViewRef.current = new View(

--- a/src/canvas/views/ReactEventsView.js
+++ b/src/canvas/views/ReactEventsView.js
@@ -26,38 +26,38 @@ import {
 } from '../constants';
 
 export class ReactEventsView extends View {
-  profilerData: ReactProfilerData;
-  intrinsicSize: Size;
+  _profilerData: ReactProfilerData;
+  _intrinsicSize: Size;
 
-  hoveredEvent: ReactEvent | null = null;
+  _hoveredEvent: ReactEvent | null = null;
   onHover: ((event: ReactEvent | null) => void) | null = null;
 
   constructor(surface: Surface, frame: Rect, profilerData: ReactProfilerData) {
     super(surface, frame);
-    this.profilerData = profilerData;
+    this._profilerData = profilerData;
 
-    this.intrinsicSize = {
-      width: this.profilerData.duration,
+    this._intrinsicSize = {
+      width: this._profilerData.duration,
       height: EVENT_ROW_HEIGHT_FIXED,
     };
   }
 
   desiredSize() {
-    return this.intrinsicSize;
+    return this._intrinsicSize;
   }
 
   setHoveredEvent(hoveredEvent: ReactEvent | null) {
-    if (this.hoveredEvent === hoveredEvent) {
+    if (this._hoveredEvent === hoveredEvent) {
       return;
     }
-    this.hoveredEvent = hoveredEvent;
+    this._hoveredEvent = hoveredEvent;
     this.setNeedsDisplay();
   }
 
   /**
    * Draw a single `ReactEvent` as a circle in the canvas.
    */
-  drawSingleReactEvent(
+  _drawSingleReactEvent(
     context: CanvasRenderingContext2D,
     rect: Rect,
     event: ReactEvent,
@@ -122,8 +122,8 @@ export class ReactEventsView extends View {
   draw(context: CanvasRenderingContext2D) {
     const {
       frame,
-      profilerData: {events},
-      hoveredEvent,
+      _profilerData: {events},
+      _hoveredEvent,
       visibleArea,
     } = this;
 
@@ -137,13 +137,16 @@ export class ReactEventsView extends View {
 
     // Draw events
     const baseY = frame.origin.y + REACT_EVENT_ROW_PADDING;
-    const scaleFactor = positioningScaleFactor(this.intrinsicSize.width, frame);
+    const scaleFactor = positioningScaleFactor(
+      this._intrinsicSize.width,
+      frame,
+    );
 
     events.forEach(event => {
-      if (event === hoveredEvent) {
+      if (event === _hoveredEvent) {
         return;
       }
-      this.drawSingleReactEvent(
+      this._drawSingleReactEvent(
         context,
         visibleArea,
         event,
@@ -155,11 +158,11 @@ export class ReactEventsView extends View {
 
     // Draw the hovered and/or selected items on top so they stand out.
     // This is helpful if there are multiple (overlapping) items close to each other.
-    if (hoveredEvent !== null) {
-      this.drawSingleReactEvent(
+    if (_hoveredEvent !== null) {
+      this._drawSingleReactEvent(
         context,
         visibleArea,
-        hoveredEvent,
+        _hoveredEvent,
         baseY,
         scaleFactor,
         true,
@@ -196,7 +199,7 @@ export class ReactEventsView extends View {
   /**
    * @private
    */
-  handleHover(interaction: HoverInteraction) {
+  _handleHover(interaction: HoverInteraction) {
     const {frame, onHover, visibleArea} = this;
     if (!onHover) {
       return;
@@ -209,9 +212,12 @@ export class ReactEventsView extends View {
     }
 
     const {
-      profilerData: {events},
+      _profilerData: {events},
     } = this;
-    const scaleFactor = positioningScaleFactor(this.intrinsicSize.width, frame);
+    const scaleFactor = positioningScaleFactor(
+      this._intrinsicSize.width,
+      frame,
+    );
     const hoverTimestamp = positionToTimestamp(location.x, scaleFactor, frame);
     const eventTimestampAllowance = widthToDuration(
       REACT_EVENT_SIZE / 2,
@@ -239,7 +245,7 @@ export class ReactEventsView extends View {
   handleInteraction(interaction: Interaction) {
     switch (interaction.type) {
       case 'hover':
-        this.handleHover(interaction);
+        this._handleHover(interaction);
         break;
     }
   }

--- a/src/canvas/views/TimeAxisMarkersView.js
+++ b/src/canvas/views/TimeAxisMarkersView.js
@@ -28,27 +28,27 @@ import {
 } from '../constants';
 
 export class TimeAxisMarkersView extends View {
-  totalDuration: number;
-  intrinsicSize: Size;
+  _totalDuration: number;
+  _intrinsicSize: Size;
 
   constructor(surface: Surface, frame: Rect, totalDuration: number) {
     super(surface, frame);
-    this.totalDuration = totalDuration;
-    this.intrinsicSize = {
-      width: this.totalDuration,
+    this._totalDuration = totalDuration;
+    this._intrinsicSize = {
+      width: this._totalDuration,
       height: HEADER_HEIGHT_FIXED,
     };
   }
 
   desiredSize() {
-    return this.intrinsicSize;
+    return this._intrinsicSize;
   }
 
   // Time mark intervals vary based on the current zoom range and the time it represents.
   // In Chrome, these seem to range from 70-140 pixels wide.
   // Time wise, they represent intervals of e.g. 1s, 500ms, 200ms, 100ms, 50ms, 20ms.
   // Based on zoom, we should determine which amount to actually show.
-  getTimeTickInterval(scaleFactor: number): number {
+  _getTimeTickInterval(scaleFactor: number): number {
     for (let i = 0; i < INTERVAL_TIMES.length; i++) {
       const currentInterval = INTERVAL_TIMES[i];
       const intervalWidth = durationToWidth(currentInterval, scaleFactor);
@@ -60,12 +60,12 @@ export class TimeAxisMarkersView extends View {
   }
 
   draw(context: CanvasRenderingContext2D) {
-    const {frame, intrinsicSize, visibleArea} = this;
+    const {frame, _intrinsicSize, visibleArea} = this;
     const clippedFrame = {
       origin: frame.origin,
       size: {
         width: frame.size.width,
-        height: intrinsicSize.height,
+        height: _intrinsicSize.height,
       },
     };
     const drawableRect = rectIntersectionWithRect(clippedFrame, visibleArea);
@@ -80,10 +80,10 @@ export class TimeAxisMarkersView extends View {
     );
 
     const scaleFactor = positioningScaleFactor(
-      intrinsicSize.width,
+      _intrinsicSize.width,
       clippedFrame,
     );
-    const interval = this.getTimeTickInterval(scaleFactor);
+    const interval = this._getTimeTickInterval(scaleFactor);
     const firstIntervalTimestamp =
       Math.ceil(
         positionToTimestamp(

--- a/src/layout/Surface.js
+++ b/src/layout/Surface.js
@@ -14,16 +14,16 @@ import {zeroPoint} from './geometry';
  */
 export class Surface {
   rootView: ?View;
-  context: ?CanvasRenderingContext2D;
-  canvasSize: ?Size;
+  _context: ?CanvasRenderingContext2D;
+  _canvasSize: ?Size;
 
   setCanvas(canvas: HTMLCanvasElement, canvasSize: Size) {
-    this.context = getCanvasContext(
+    this._context = getCanvasContext(
       canvas,
       canvasSize.height,
       canvasSize.width,
     );
-    this.canvasSize = canvasSize;
+    this._canvasSize = canvasSize;
 
     if (this.rootView) {
       this.rootView.setNeedsDisplay();
@@ -31,19 +31,19 @@ export class Surface {
   }
 
   displayIfNeeded() {
-    const {rootView, canvasSize, context} = this;
-    if (!rootView || !context || !canvasSize) {
+    const {rootView, _canvasSize, _context} = this;
+    if (!rootView || !_context || !_canvasSize) {
       return;
     }
     rootView.setFrame({
       origin: zeroPoint,
-      size: canvasSize,
+      size: _canvasSize,
     });
     rootView.setVisibleArea({
       origin: zeroPoint,
-      size: canvasSize,
+      size: _canvasSize,
     });
-    rootView.displayIfNeeded(context);
+    rootView.displayIfNeeded(_context);
   }
 
   handleInteraction(interaction: Interaction) {

--- a/src/layout/VerticalScrollView.js
+++ b/src/layout/VerticalScrollView.js
@@ -36,20 +36,16 @@ function clamp(min: number, max: number, value: number): number {
 }
 
 export class VerticalScrollView extends View {
-  /**
-   * Reference to the content view. This view is also the only view in
-   * `this.subviews`.
-   */
-  contentView: View;
-
-  scrollState: VerticalScrollState = {
+  _scrollState: VerticalScrollState = {
     offsetY: 0,
   };
 
-  stateDeriver: (state: VerticalScrollState) => VerticalScrollState = state =>
+  _isPanning = false;
+
+  _stateDeriver: (state: VerticalScrollState) => VerticalScrollState = state =>
     state;
 
-  onStateChange: (state: VerticalScrollState) => void = () => {};
+  _onStateChange: (state: VerticalScrollState) => void = () => {};
 
   constructor(
     surface: Surface,
@@ -59,17 +55,16 @@ export class VerticalScrollView extends View {
     onStateChange?: (state: VerticalScrollState) => void,
   ) {
     super(surface, frame);
-    this.contentView = contentView;
-    this.addSubview(this.contentView);
-    if (stateDeriver) this.stateDeriver = stateDeriver;
-    if (onStateChange) this.onStateChange = onStateChange;
+    this.addSubview(contentView);
+    if (stateDeriver) this._stateDeriver = stateDeriver;
+    if (onStateChange) this._onStateChange = onStateChange;
   }
 
   setFrame(newFrame: Rect) {
     super.setFrame(newFrame);
 
     // Revalidate scrollState
-    this.updateState(this.scrollState);
+    this._updateState(this._scrollState);
   }
 
   desiredSize() {
@@ -78,9 +73,17 @@ export class VerticalScrollView extends View {
     return null;
   }
 
+  /**
+   * Reference to the content view. This view is also the only view in
+   * `this.subviews`.
+   */
+  get _contentView() {
+    return this.subviews[0];
+  }
+
   layoutSubviews() {
-    const {offsetY} = this.scrollState;
-    const desiredSize = this.contentView.desiredSize();
+    const {offsetY} = this._scrollState;
+    const desiredSize = this._contentView.desiredSize();
 
     const minimumHeight = this.frame.size.height;
     const desiredHeight = desiredSize ? desiredSize.height : 0;
@@ -97,37 +100,35 @@ export class VerticalScrollView extends View {
         height,
       },
     };
-    this.contentView.setFrame(proposedFrame);
+    this._contentView.setFrame(proposedFrame);
     super.layoutSubviews();
   }
 
-  isPanning = false;
-
-  handleVerticalPanStart(interaction: VerticalPanStartInteraction) {
+  _handleVerticalPanStart(interaction: VerticalPanStartInteraction) {
     if (rectContainsPoint(interaction.payload.location, this.frame)) {
-      this.isPanning = true;
+      this._isPanning = true;
     }
   }
 
-  handleVerticalPanMove(interaction: VerticalPanMoveInteraction) {
-    if (!this.isPanning) {
+  _handleVerticalPanMove(interaction: VerticalPanMoveInteraction) {
+    if (!this._isPanning) {
       return;
     }
-    const {offsetY} = this.scrollState;
+    const {offsetY} = this._scrollState;
     const {movementY} = interaction.payload.event;
-    this.updateState({
-      ...this.scrollState,
+    this._updateState({
+      ...this._scrollState,
       offsetY: offsetY + movementY,
     });
   }
 
-  handleVerticalPanEnd(interaction: VerticalPanEndInteraction) {
-    if (this.isPanning) {
-      this.isPanning = false;
+  _handleVerticalPanEnd(interaction: VerticalPanEndInteraction) {
+    if (this._isPanning) {
+      this._isPanning = false;
     }
   }
 
-  handleWheelPlain(interaction: WheelPlainInteraction) {
+  _handleWheelPlain(interaction: WheelPlainInteraction) {
     const {
       location,
       event: {deltaX, deltaY},
@@ -146,25 +147,25 @@ export class VerticalScrollView extends View {
       return;
     }
 
-    this.updateState({
-      ...this.scrollState,
-      offsetY: this.scrollState.offsetY - deltaY,
+    this._updateState({
+      ...this._scrollState,
+      offsetY: this._scrollState.offsetY - deltaY,
     });
   }
 
   handleInteraction(interaction: Interaction) {
     switch (interaction.type) {
       case 'vertical-pan-start':
-        this.handleVerticalPanStart(interaction);
+        this._handleVerticalPanStart(interaction);
         break;
       case 'vertical-pan-move':
-        this.handleVerticalPanMove(interaction);
+        this._handleVerticalPanMove(interaction);
         break;
       case 'vertical-pan-end':
-        this.handleVerticalPanEnd(interaction);
+        this._handleVerticalPanEnd(interaction);
         break;
       case 'wheel-plain':
-        this.handleWheelPlain(interaction);
+        this._handleWheelPlain(interaction);
         break;
     }
   }
@@ -172,13 +173,13 @@ export class VerticalScrollView extends View {
   /**
    * @private
    */
-  updateState(proposedState: VerticalScrollState) {
-    const clampedState = this.stateDeriver(
-      this.clampedProposedState(proposedState),
+  _updateState(proposedState: VerticalScrollState) {
+    const clampedState = this._stateDeriver(
+      this._clampedProposedState(proposedState),
     );
-    if (!scrollStatesAreEqual(clampedState, this.scrollState)) {
-      this.scrollState = clampedState;
-      this.onStateChange(this.scrollState);
+    if (!scrollStatesAreEqual(clampedState, this._scrollState)) {
+      this._scrollState = clampedState;
+      this._onStateChange(this._scrollState);
       this.setNeedsDisplay();
     }
   }
@@ -186,12 +187,12 @@ export class VerticalScrollView extends View {
   /**
    * @private
    */
-  clampedProposedState(
+  _clampedProposedState(
     proposedState: VerticalScrollState,
   ): VerticalScrollState {
     return {
       offsetY: clamp(
-        -(this.contentView.frame.size.height - this.frame.size.height),
+        -(this._contentView.frame.size.height - this.frame.size.height),
         0,
         proposedState.offsetY,
       ),

--- a/src/layout/View.js
+++ b/src/layout/View.js
@@ -29,8 +29,11 @@ export class View {
   superview: ?View;
   subviews: View[] = [];
 
-  /** An injected function that lays out our subviews. */
-  layouter: Layouter;
+  /**
+   * An injected function that lays out our subviews.
+   * @private
+   */
+  _layouter: Layouter;
 
   /**
    * Whether this view needs to be drawn.
@@ -40,7 +43,7 @@ export class View {
    * @see setNeedsDisplay
    * @private
    */
-  needsDisplay = true;
+  _needsDisplay = true;
 
   /**
    * Whether the heirarchy below this view has subviews that need display.
@@ -50,7 +53,7 @@ export class View {
    * @see setSubviewsNeedDisplay
    * @private
    */
-  subviewsNeedDisplay = false;
+  _subviewsNeedDisplay = false;
 
   constructor(
     surface: Surface,
@@ -60,7 +63,7 @@ export class View {
   ) {
     this.surface = surface;
     this.frame = frame;
-    this.layouter = layouter;
+    this._layouter = layouter;
     this.visibleArea = visibleArea;
   }
 
@@ -71,9 +74,9 @@ export class View {
    * be invalidated.
    */
   setNeedsDisplay() {
-    this.needsDisplay = true;
+    this._needsDisplay = true;
     if (this.superview) {
-      this.superview.setSubviewsNeedDisplay();
+      this.superview._setSubviewsNeedDisplay();
     }
     this.subviews.forEach(subview => subview.setNeedsDisplay());
   }
@@ -86,10 +89,10 @@ export class View {
    *
    * @private
    */
-  setSubviewsNeedDisplay() {
-    this.subviewsNeedDisplay = true;
+  _setSubviewsNeedDisplay() {
+    this._subviewsNeedDisplay = true;
     if (this.superview) {
-      this.superview.setSubviewsNeedDisplay();
+      this.superview._setSubviewsNeedDisplay();
     }
   }
 
@@ -128,7 +131,7 @@ export class View {
    * Can be overridden by subclasses.
    */
   desiredSize(): ?Size {
-    if (this.needsDisplay) {
+    if (this._needsDisplay) {
       this.layoutSubviews();
     }
     const frames = this.subviews.map(subview => subview.frame);
@@ -175,13 +178,13 @@ export class View {
    */
   displayIfNeeded(context: CanvasRenderingContext2D) {
     if (
-      (this.needsDisplay || this.subviewsNeedDisplay) &&
+      (this._needsDisplay || this._subviewsNeedDisplay) &&
       rectIntersectsRect(this.frame, this.visibleArea) &&
       !sizeIsEmpty(this.visibleArea.size)
     ) {
       this.layoutSubviews();
-      if (this.needsDisplay) this.needsDisplay = false;
-      if (this.subviewsNeedDisplay) this.subviewsNeedDisplay = false;
+      if (this._needsDisplay) this._needsDisplay = false;
+      if (this._subviewsNeedDisplay) this._subviewsNeedDisplay = false;
       this.draw(context);
     }
   }
@@ -201,9 +204,9 @@ export class View {
    * @see displayIfNeeded
    */
   layoutSubviews() {
-    const {frame, layouter, subviews, visibleArea} = this;
+    const {frame, _layouter, subviews, visibleArea} = this;
     const existingLayout = viewsToLayout(subviews);
-    const newLayout = layouter(existingLayout, frame);
+    const newLayout = _layouter(existingLayout, frame);
     collapseLayoutIntoViews(newLayout);
 
     subviews.forEach((subview, subviewIndex) => {


### PR DESCRIPTION
Stack PR by [STACK ATTACK](https://github.com/taneliang/stack-attack):
- #99 [Improve base View][1/n] Add subview handling to View
- #100 [Improve base View][2/n] Rationalize view layout system
- **#101 [Improve base View][3/n] Add _ to views' private vars and methods**
- #102 [Improve base View][4/n] Write tests for geometry.js

Our classes have many private vars and methods. As JS classes don't have private methods and vars yet (I don't believe React has enabled transpilation of the new `#` syntax), I've followed existing JS convention and prefixed them with `_`s.