### PR TITLE
fix: text link transition

### DIFF
--- a/src/ImportPage.css
+++ b/src/ImportPage.css
@@ -14,11 +14,9 @@
 
 .link {
   color: #282c34;
-  transition: 0.2s;
 }
 .link:hover {
   color: #61dafb;
-  transition: 0.2s;
 }
 
 kbd {

--- a/src/ImportPage.css
+++ b/src/ImportPage.css
@@ -14,9 +14,13 @@
 
 .link {
   color: #282c34;
+  transition: 0.2s;
+  font-size: calc(10px + 1.5vmin);
 }
 .link:hover {
   color: #61dafb;
+  transition: 0.2s;
+  font-size: calc(10px + 1.5vmin);
 }
 
 kbd {


### PR DESCRIPTION
hi, 

try to fix **Import page link text animates at a different speed compared to the rest of the page's text #65**
 
