### PR TITLE
[Resize content][2/n] Implement ResizableSplitView

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "d3-hierarchy": "^1.1.9",
     "lodash.clonedeep": "^4.5.0",
     "memoize-one": "^5.1.1",
+    "nullthrows": "^1.1.1",
     "pretty-ms": "^7.0.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",

--- a/src/CanvasPage.js
+++ b/src/CanvasPage.js
@@ -14,9 +14,12 @@ import React, {
 
 import {
   HorizontalPanAndZoomView,
+  ResizableSplitView,
   Surface,
   VerticalScrollView,
   View,
+  createComposedLayout,
+  lastViewTakesUpRemainingSpaceLayout,
   verticallyStackedLayout,
   zeroPoint,
 } from './layout';
@@ -180,16 +183,21 @@ function AutoSizedCanvas({data, height, width}: AutoSizedCanvasProps) {
       data.duration,
     );
 
-    // TODO: Replace with ResizableSplitView
-    const resizableContentStack = new View(
+    const resizableContentStack = new ResizableSplitView(
       surface,
       defaultFrame,
-      verticallyStackedLayout,
+      hScrollWrappedReactMeasuresView,
+      hScrollWrappedFlamechartView,
     );
-    resizableContentStack.addSubview(hScrollWrappedReactMeasuresView);
-    resizableContentStack.addSubview(hScrollWrappedFlamechartView);
 
-    const rootView = new View(surface, defaultFrame, verticallyStackedLayout);
+    const rootView = new View(
+      surface,
+      defaultFrame,
+      createComposedLayout(
+        verticallyStackedLayout,
+        lastViewTakesUpRemainingSpaceLayout,
+      ),
+    );
     rootView.addSubview(topContentZoomWrapper);
     rootView.addSubview(resizableContentStack);
 

--- a/src/layout/ColorView.js
+++ b/src/layout/ColorView.js
@@ -16,6 +16,14 @@ export class ColorView extends View {
     this._color = color;
   }
 
+  setColor(color: string) {
+    if (this._color === color) {
+      return;
+    }
+    this._color = color;
+    this.setNeedsDisplay();
+  }
+
   draw(context: CanvasRenderingContext2D) {
     const {_color, visibleArea} = this;
     context.fillStyle = _color;

--- a/src/layout/ResizableSplitView.js
+++ b/src/layout/ResizableSplitView.js
@@ -1,0 +1,313 @@
+// @flow
+
+import type {
+  Interaction,
+  VerticalPanStartInteraction,
+  VerticalPanMoveInteraction,
+  VerticalPanEndInteraction,
+} from '../useCanvasInteraction';
+import type {Rect, Size} from './geometry';
+
+import nullthrows from 'nullthrows';
+import {Surface} from './Surface';
+import {View} from './View';
+import {rectContainsPoint} from './geometry';
+import {layeredLayout, noopLayout} from './layouter';
+import {ColorView} from './ColorView';
+
+type ResizeBarState = 'normal' | 'hovered' | 'dragging';
+
+type ResizingState = $ReadOnly<{|
+  /** Distance between top of resize bar and mouseY */
+  cursorOffsetInBarFrame: number,
+  /** Mouse's vertical coordinates relative to canvas */
+  mouseY: number,
+|}>;
+
+type LayoutState = $ReadOnly<{|
+  /** Resize bar's vertical position relative to resize view's frame.origin.y */
+  barOffsetY: number,
+|}>;
+
+// TODO: Deduplicate
+function clamp(min: number, max: number, value: number): number {
+  if (Number.isNaN(min) || Number.isNaN(max) || Number.isNaN(value)) {
+    throw new Error(
+      `Clamp was called with NaN. Args: min: ${min}, max: ${max}, value: ${value}.`,
+    );
+  }
+  return Math.min(max, Math.max(min, value));
+}
+
+function getColorForBarState(state: ResizeBarState): string {
+  // Colors obtained from Firefox Profiler
+  switch (state) {
+    case 'normal':
+      return '#ccc';
+    case 'hovered':
+      return '#bbb';
+    case 'dragging':
+      return '#aaa';
+  }
+  throw new Error(`Unknown resize bar state ${state}`);
+}
+
+class ResizeBar extends View {
+  _intrinsicContentSize: Size = {
+    width: 0,
+    height: 5,
+  };
+
+  _interactionState: ResizeBarState = 'normal';
+
+  constructor(surface: Surface, frame: Rect) {
+    super(surface, frame, layeredLayout);
+    this.addSubview(new ColorView(surface, frame, ''));
+    this._updateColor();
+  }
+
+  desiredSize() {
+    return this._intrinsicContentSize;
+  }
+
+  _getColorView(): ColorView {
+    return (this.subviews[0]: any);
+  }
+
+  _updateColor() {
+    this._getColorView().setColor(getColorForBarState(this._interactionState));
+  }
+
+  _setInteractionState(state: ResizeBarState) {
+    if (this._interactionState === state) {
+      return;
+    }
+    this._interactionState = state;
+    this._updateColor();
+  }
+
+  _handleVerticalPanStart(interaction: VerticalPanStartInteraction) {
+    const cursorInView = rectContainsPoint(
+      interaction.payload.location,
+      this.frame,
+    );
+    if (cursorInView) {
+      this._setInteractionState('dragging');
+    }
+  }
+
+  _handleVerticalPanMove(interaction: VerticalPanMoveInteraction) {
+    const cursorInView = rectContainsPoint(
+      interaction.payload.location,
+      this.frame,
+    );
+    if (this._interactionState === 'dragging') {
+      return;
+    }
+    this._setInteractionState(cursorInView ? 'hovered' : 'normal');
+  }
+
+  _handleVerticalPanEnd(interaction: VerticalPanEndInteraction) {
+    const cursorInView = rectContainsPoint(
+      interaction.payload.location,
+      this.frame,
+    );
+    if (this._interactionState === 'dragging') {
+      this._setInteractionState(cursorInView ? 'hovered' : 'normal');
+    }
+  }
+
+  handleInteraction(interaction: Interaction) {
+    switch (interaction.type) {
+      case 'vertical-pan-start':
+        this._handleVerticalPanStart(interaction);
+        return;
+      case 'vertical-pan-move':
+        this._handleVerticalPanMove(interaction);
+        return;
+      case 'vertical-pan-end':
+        this._handleVerticalPanEnd(interaction);
+        return;
+    }
+  }
+}
+
+export class ResizableSplitView extends View {
+  _resizingState: ResizingState | null = null;
+  _layoutState: LayoutState;
+
+  constructor(
+    surface: Surface,
+    frame: Rect,
+    topSubview: View,
+    bottomSubview: View,
+  ) {
+    super(surface, frame, noopLayout);
+
+    this.addSubview(topSubview);
+    this.addSubview(new ResizeBar(surface, frame));
+    this.addSubview(bottomSubview);
+
+    const topSubviewDesiredSize = topSubview.desiredSize();
+    this._layoutState = {
+      barOffsetY: topSubviewDesiredSize ? topSubviewDesiredSize.height : 0,
+    };
+  }
+
+  _getTopSubview(): View {
+    return this.subviews[0];
+  }
+
+  _getResizeBar(): View {
+    return this.subviews[1];
+  }
+
+  _getBottomSubview(): View {
+    return this.subviews[2];
+  }
+
+  _getResizeBarDesiredSize(): Size {
+    return nullthrows(
+      this._getResizeBar().desiredSize(),
+      'Resize bar must have desired size',
+    );
+  }
+
+  desiredSize() {
+    const topSubviewDesiredSize = this._getTopSubview().desiredSize();
+    const resizeBarDesiredSize = this._getResizeBarDesiredSize();
+    const bottomSubviewDesiredSize = this._getBottomSubview().desiredSize();
+
+    const topSubviewDesiredWidth = topSubviewDesiredSize
+      ? topSubviewDesiredSize.width
+      : 0;
+    const bottomSubviewDesiredWidth = bottomSubviewDesiredSize
+      ? bottomSubviewDesiredSize.width
+      : 0;
+
+    const topSubviewDesiredHeight = topSubviewDesiredSize
+      ? topSubviewDesiredSize.height
+      : 0;
+    const bottomSubviewDesiredHeight = bottomSubviewDesiredSize
+      ? bottomSubviewDesiredSize.height
+      : 0;
+
+    return {
+      width: Math.max(
+        topSubviewDesiredWidth,
+        resizeBarDesiredSize.width,
+        bottomSubviewDesiredWidth,
+      ),
+      height:
+        topSubviewDesiredHeight +
+        resizeBarDesiredSize.height +
+        bottomSubviewDesiredHeight,
+    };
+  }
+
+  layoutSubviews() {
+    this._updateLayoutState();
+    this._updateSubviewFrames();
+    super.layoutSubviews();
+  }
+
+  _updateLayoutState() {
+    const {frame, visibleArea, _resizingState} = this;
+
+    const resizeBarDesiredSize = this._getResizeBarDesiredSize();
+    // Allow bar to travel to bottom of the visible area of this view but no further
+    const maxPossibleBarOffset =
+      visibleArea.size.height - resizeBarDesiredSize.height;
+    const topSubviewDesiredSize = this._getTopSubview().desiredSize();
+    const maxBarOffset = topSubviewDesiredSize
+      ? Math.min(maxPossibleBarOffset, topSubviewDesiredSize.height)
+      : maxPossibleBarOffset;
+
+    let proposedBarOffsetY = this._layoutState.barOffsetY;
+    // Update bar offset if dragging bar
+    if (_resizingState) {
+      const {mouseY, cursorOffsetInBarFrame} = _resizingState;
+      proposedBarOffsetY = mouseY - frame.origin.y - cursorOffsetInBarFrame;
+    }
+
+    this._layoutState = {
+      ...this._layoutState,
+      barOffsetY: clamp(0, maxBarOffset, proposedBarOffsetY),
+    };
+  }
+
+  _updateSubviewFrames() {
+    const {
+      frame: {
+        origin: {x, y},
+        size: {width, height},
+      },
+      _layoutState: {barOffsetY},
+    } = this;
+
+    const resizeBarDesiredSize = this._getResizeBarDesiredSize();
+
+    let currentY = y;
+
+    this._getTopSubview().setFrame({
+      origin: {x, y: currentY},
+      size: {width, height: barOffsetY},
+    });
+    currentY += this._getTopSubview().frame.size.height;
+
+    this._getResizeBar().setFrame({
+      origin: {x, y: currentY},
+      size: {width, height: resizeBarDesiredSize.height},
+    });
+    currentY += this._getResizeBar().frame.size.height;
+
+    this._getBottomSubview().setFrame({
+      origin: {x, y: currentY},
+      // Fill remaining height
+      size: {width, height: height + y - currentY},
+    });
+  }
+
+  _handleVerticalPanStart(interaction: VerticalPanStartInteraction) {
+    const cursorLocation = interaction.payload.location;
+    const resizeBarFrame = this._getResizeBar().frame;
+    if (rectContainsPoint(cursorLocation, resizeBarFrame)) {
+      const mouseY = cursorLocation.y;
+      this._resizingState = {
+        cursorOffsetInBarFrame: mouseY - resizeBarFrame.origin.y,
+        mouseY,
+      };
+    }
+  }
+
+  _handleVerticalPanMove(interaction: VerticalPanMoveInteraction) {
+    const {_resizingState} = this;
+    if (_resizingState) {
+      this._resizingState = {
+        ..._resizingState,
+        mouseY: interaction.payload.location.y,
+      };
+      this.setNeedsDisplay();
+    }
+  }
+
+  _handleVerticalPanEnd(interaction: VerticalPanEndInteraction) {
+    if (this._resizingState) {
+      this._resizingState = null;
+    }
+  }
+
+  handleInteraction(interaction: Interaction) {
+    switch (interaction.type) {
+      case 'vertical-pan-start':
+        this._handleVerticalPanStart(interaction);
+        return;
+      case 'vertical-pan-move':
+        this._handleVerticalPanMove(interaction);
+        return;
+      case 'vertical-pan-end':
+        this._handleVerticalPanEnd(interaction);
+        return;
+    }
+  }
+}

--- a/src/layout/index.js
+++ b/src/layout/index.js
@@ -2,6 +2,7 @@
 
 export * from './ColorView';
 export * from './HorizontalPanAndZoomView';
+export * from './ResizableSplitView';
 export * from './Surface';
 export * from './VerticalScrollView';
 export * from './View';

--- a/src/layout/layouter.js
+++ b/src/layout/layouter.js
@@ -200,6 +200,50 @@ export const atLeastContainerHeightLayout: Layouter = (
 };
 
 /**
+ * Forces last view to take up the space below the second-last view.
+ * Intended to be used with a vertical stack layout.
+ */
+export const lastViewTakesUpRemainingSpaceLayout: Layouter = (
+  layout,
+  containerFrame,
+) => {
+  if (layout.length === 0) {
+    // Nothing to do
+    return layout;
+  }
+
+  if (layout.length === 1) {
+    // No second-last view; the view should just take up the container height
+    return containerHeightLayout(layout, containerFrame);
+  }
+
+  const layoutInfoToPassThrough = layout.slice(0, layout.length - 1);
+  const secondLastLayoutInfo =
+    layoutInfoToPassThrough[layoutInfoToPassThrough.length - 1];
+
+  const remainingHeight =
+    containerFrame.size.height -
+    secondLastLayoutInfo.frame.origin.y -
+    secondLastLayoutInfo.frame.size.height;
+  const height = Math.max(remainingHeight, 0); // Prevent negative heights
+
+  const lastLayoutInfo = layout[layout.length - 1];
+  return [
+    ...layoutInfoToPassThrough,
+    {
+      ...lastLayoutInfo,
+      frame: {
+        origin: lastLayoutInfo.frame.origin,
+        size: {
+          width: lastLayoutInfo.frame.size.width,
+          height,
+        },
+      },
+    },
+  ];
+};
+
+/**
  * Create a layouter that applies each layouter in `layouters` in sequence.
  */
 export function createComposedLayout(...layouters: Layouter[]): Layouter {


### PR DESCRIPTION
Stack PR by [STACK ATTACK](https://github.com/taneliang/stack-attack):
- #110 [Resize content][1/n] Break horizontal scrolling area into final-ish hierarchy
- **#107 [Resize content][2/n] Implement ResizableSplitView**
- #108 [Resize content][3/n] Sync horizontal pan and zoom states
- #109 Implement User Timing marks view
- #111 Highlight React events with the same wakeable ID

Summary
---

Implements `ResizableSplitView` and uses it to allow resizing of the
React measures view.

This PR also fixes the last PR's known issue where the flamechart does
not scroll vertically.

Resolves #19, resolves #70.

Test Plan
---

* `yarn lint`
* `yarn flow`: no errors in changed code
* `yarn test`: no added tests, but everything still passes
* `yarn start`: manual testing:
	![image](https://user-images.githubusercontent.com/12784593/89156856-08f45200-d59e-11ea-8f36-79a7aa9e35fa.png)
    * Hover over resize bar to observe color change
    * Drag resize bar to resize
		![image](https://user-images.githubusercontent.com/12784593/89156881-1578aa80-d59e-11ea-9477-30737bfce495.png)
    * Resize bar position is clamped and cannot go offscreen or expand
      beyond the size of the lanes area
    * Content is independently vertically scrollable
		![image](https://user-images.githubusercontent.com/12784593/89156912-245f5d00-d59e-11ea-950e-5239fdb726b5.png)
    * Resize bar remains visible on page resize
		![image](https://user-images.githubusercontent.com/12784593/89156932-2d502e80-d59e-11ea-8ffe-4aeaf7e39531.png)

There are still 3 independent horizontal pan/zoom areas, a known issue
carried over from the last PR in this stack. This will be fixed in the
next PR (#108).