### PR TITLE
[Resize content][3/n] Sync horizontal pan and zoom states

### DIFF
--- a/src/layout/VerticalScrollView.js
+++ b/src/layout/VerticalScrollView.js
@@ -14,9 +14,9 @@ import {View} from './View';
 import {rectContainsPoint} from './geometry';
 import {MOVE_WHEEL_DELTA_THRESHOLD} from '../canvas/constants'; // TODO: Remove external dependency
 
-type VerticalScrollState = {|
+type VerticalScrollState = $ReadOnly<{|
   offsetY: number,
-|};
+|}>;
 
 function scrollStatesAreEqual(
   state1: VerticalScrollState,
@@ -42,22 +42,9 @@ export class VerticalScrollView extends View {
 
   _isPanning = false;
 
-  _stateDeriver: (state: VerticalScrollState) => VerticalScrollState = state =>
-    state;
-
-  _onStateChange: (state: VerticalScrollState) => void = () => {};
-
-  constructor(
-    surface: Surface,
-    frame: Rect,
-    contentView: View,
-    stateDeriver?: (state: VerticalScrollState) => VerticalScrollState,
-    onStateChange?: (state: VerticalScrollState) => void,
-  ) {
+  constructor(surface: Surface, frame: Rect, contentView: View) {
     super(surface, frame);
     this.addSubview(contentView);
-    if (stateDeriver) this._stateDeriver = stateDeriver;
-    if (onStateChange) this._onStateChange = onStateChange;
   }
 
   setFrame(newFrame: Rect) {
@@ -172,12 +159,9 @@ export class VerticalScrollView extends View {
    * @private
    */
   _updateState(proposedState: VerticalScrollState) {
-    const clampedState = this._stateDeriver(
-      this._clampedProposedState(proposedState),
-    );
+    const clampedState = this._clampedProposedState(proposedState);
     if (!scrollStatesAreEqual(clampedState, this._scrollState)) {
       this._scrollState = clampedState;
-      this._onStateChange(this._scrollState);
       this.setNeedsDisplay();
     }
   }


### PR DESCRIPTION
Stack PR by [STACK ATTACK](https://github.com/taneliang/stack-attack):
- #110 [Resize content][1/n] Break horizontal scrolling area into final-ish hierarchy
- #107 [Resize content][2/n] Implement ResizableSplitView
- **#108 [Resize content][3/n] Sync horizontal pan and zoom states**
- #109 Implement User Timing marks view
- #111 Highlight React events with the same wakeable ID

Summary
---

Syncs the state of all 3 horizontal pan and zoom views.

Fixes the known issue from the first PR in this stack.

Test Plan
---

* `yarn lint`
* `yarn flow`: no errors in changed code
* `yarn test`: no new tests; all existing ones passing
* `yarn start`: manual test: panning and zooming on any horizontal pan
  and zoom view also pans and zooms the others.