### PR TITLE
[Resize content][1/n] Break horizontal scrolling area into final-ish hierarchy

### DIFF
--- a/src/layout/HorizontalPanAndZoomView.js
+++ b/src/layout/HorizontalPanAndZoomView.js
@@ -93,9 +93,7 @@ export class HorizontalPanAndZoomView extends View {
   }
 
   desiredSize() {
-    // We don't want our superview to fit to our content; we'll fit whatever
-    // frame we're given.
-    return null;
+    return this._contentView.desiredSize();
   }
 
   /**

--- a/src/layout/VerticalScrollView.js
+++ b/src/layout/VerticalScrollView.js
@@ -68,9 +68,7 @@ export class VerticalScrollView extends View {
   }
 
   desiredSize() {
-    // We don't want our superview to fit to our content; we'll fit whatever
-    // frame we're given.
-    return null;
+    return this._contentView.desiredSize();
   }
 
   /**


### PR DESCRIPTION
Stack PR by [STACK ATTACK](https://github.com/taneliang/stack-attack):
- **#110 [Resize content][1/n] Break horizontal scrolling area into final-ish hierarchy**
- #107 [Resize content][2/n] Implement ResizableSplitView
- #108 [Resize content][3/n] Sync horizontal pan and zoom states
- #109 Implement User Timing marks view
- #111 Highlight React events with the same wakeable ID

Summary
---

This PR begins a PR stack that implements the resize of the lanes area.

In this PR, the view hierarchy is overhauled to more closely resemble
the final one. This is the new view hierarchy:

- View (vertically stacked layout) (root view)
  - HorizontalPanAndZoomView
    - View (vertically stacked layout)
      - TimeAxisMarkersView
      - ReactEventsView
  - View (vertically stacked layout) (to be replaced with
    ResizableVerticalSplitView)
    - HorizontalPanAndZoomView
      - VerticalScrollView
        - ReactMeasuresView
    - HorizontalPanAndZoomView
      - VerticalScrollView
        - FlamechartView

This PR must be landed with the PRs stacked above it in order not to
break master.

Test Plan
---

* `yarn lint`
* `yarn flow`: no errors in changed code
* `yarn test`

Known issues
---

* There are now 3 independent horizontal pan/zoom areas. This is
  intentional; it'll be fixed in a future PR in this stack (#108).
* Flamechart no longer scrolls vertically. This will be fixed in a
  future PR in this stack (#107).