### PR TITLE
Improve Firefox scrolling performance

### DIFF
--- a/src/canvas/views/FlamechartView.js
+++ b/src/canvas/views/FlamechartView.js
@@ -184,12 +184,14 @@ class FlamechartStackLayerView extends View {
           );
           if (textOverflowsViewableArea) {
             context.save();
+            context.beginPath();
             context.rect(
               drawableRect.origin.x,
               drawableRect.origin.y,
               drawableRect.size.width,
               drawableRect.size.height,
             );
+            context.closePath();
             context.clip();
           }
 

--- a/src/useCanvasInteraction.js
+++ b/src/useCanvasInteraction.js
@@ -95,6 +95,23 @@ export type Interaction =
   | WheelWithControlInteraction
   | WheelWithMetaInteraction;
 
+let canvasBoundingRectCache = null;
+function cacheFirstGetCanvasBoundingRect(canvas) {
+  if (
+    canvasBoundingRectCache &&
+    canvas.width === canvasBoundingRectCache.width &&
+    canvas.height === canvasBoundingRectCache.height
+  ) {
+    return canvasBoundingRectCache.rect;
+  }
+  canvasBoundingRectCache = {
+    width: canvas.width,
+    height: canvas.height,
+    rect: canvas.getBoundingClientRect(),
+  };
+  return canvasBoundingRectCache.rect;
+}
+
 export function useCanvasInteraction(
   canvasRef: {|current: HTMLCanvasElement | null|},
   interactor: (interaction: Interaction) => void,
@@ -106,7 +123,7 @@ export function useCanvasInteraction(
       if (!canvas) {
         return localCoordinates;
       }
-      const canvasRect = canvas.getBoundingClientRect();
+      const canvasRect = cacheFirstGetCanvasBoundingRect(canvas);
       return {
         x: localCoordinates.x - canvasRect.left,
         y: localCoordinates.y - canvasRect.top,


### PR DESCRIPTION
Resolves #105 with 2 strategies

1. Close paths before clipping. In Firefox, the `clip` method took a very long time to run as the `rect`s seem to build up over time. Wrapping the `rect` call in `beginPath` and `closePath` seems to reduce the amount of work that `clip` does. Scroll performance in Firefox is back to normal (~20-30 FPS)

	Before (https://share.firefox.dev/3iaqE5W):
	![image](https://user-images.githubusercontent.com/12784593/89376353-26eabf80-d722-11ea-8bc3-4268332e6674.png)

	After (https://share.firefox.dev/39UvDET):
	![image](https://user-images.githubusercontent.com/12784593/89376380-336f1800-d722-11ea-943b-70d01911ef08.png)

1. Cache canvas bounding rect if the canvas size does not change.

	Correctness: This implementation remains correct because our canvas takes up the whole page, and any change in the actual bounding rect will always result in a canvas width/height change, triggering cache invalidation. 

	Improvement: This does not result in any noticeable improvement, but `getBoundingClientRect` was significant enough to show up in performance profiles. 
![image](https://user-images.githubusercontent.com/12784593/89376186-e723d800-d721-11ea-95dc-a425f601ec4a.png)