### PR TITLE
Codemod pan/hover interactions -> mouse interactions

### DIFF
--- a/src/canvas/views/FlamechartView.js
+++ b/src/canvas/views/FlamechartView.js
@@ -1,6 +1,9 @@
 // @flow
 
-import type {Interaction, HoverInteraction} from '../../useCanvasInteraction';
+import type {
+  Interaction,
+  MouseMoveInteraction,
+} from '../../useCanvasInteraction';
 import type {
   Flamechart,
   FlamechartStackFrame,
@@ -210,7 +213,7 @@ class FlamechartStackLayerView extends View {
   /**
    * @private
    */
-  _handleHover(interaction: HoverInteraction) {
+  _handleMouseMove(interaction: MouseMoveInteraction) {
     const {_stackLayer, frame, _intrinsicSize, _onHover, visibleArea} = this;
     const {location} = interaction.payload;
     if (!_onHover || !rectContainsPoint(location, visibleArea)) {
@@ -245,8 +248,8 @@ class FlamechartStackLayerView extends View {
 
   handleInteraction(interaction: Interaction) {
     switch (interaction.type) {
-      case 'hover':
-        this._handleHover(interaction);
+      case 'mousemove':
+        this._handleMouseMove(interaction);
         break;
     }
   }
@@ -325,7 +328,7 @@ export class FlamechartView extends View {
   /**
    * @private
    */
-  _handleHover(interaction: HoverInteraction) {
+  _handleMouseMove(interaction: MouseMoveInteraction) {
     const {_onHover, visibleArea} = this;
     if (!_onHover) {
       return;
@@ -340,8 +343,8 @@ export class FlamechartView extends View {
 
   handleInteraction(interaction: Interaction) {
     switch (interaction.type) {
-      case 'hover':
-        this._handleHover(interaction);
+      case 'mousemove':
+        this._handleMouseMove(interaction);
         break;
     }
   }

--- a/src/canvas/views/ReactEventsView.js
+++ b/src/canvas/views/ReactEventsView.js
@@ -1,6 +1,9 @@
 // @flow
 
-import type {Interaction, HoverInteraction} from '../../useCanvasInteraction';
+import type {
+  Interaction,
+  MouseMoveInteraction,
+} from '../../useCanvasInteraction';
 import type {ReactEvent, ReactProfilerData} from '../../types';
 import type {Rect, Size} from '../../layout';
 
@@ -216,7 +219,7 @@ export class ReactEventsView extends View {
   /**
    * @private
    */
-  _handleHover(interaction: HoverInteraction) {
+  _handleMouseMove(interaction: MouseMoveInteraction) {
     const {frame, onHover, visibleArea} = this;
     if (!onHover) {
       return;
@@ -261,8 +264,8 @@ export class ReactEventsView extends View {
 
   handleInteraction(interaction: Interaction) {
     switch (interaction.type) {
-      case 'hover':
-        this._handleHover(interaction);
+      case 'mousemove':
+        this._handleMouseMove(interaction);
         break;
     }
   }

--- a/src/canvas/views/ReactMeasuresView.js
+++ b/src/canvas/views/ReactMeasuresView.js
@@ -1,6 +1,9 @@
 // @flow
 
-import type {Interaction, HoverInteraction} from '../../useCanvasInteraction';
+import type {
+  Interaction,
+  MouseMoveInteraction,
+} from '../../useCanvasInteraction';
 import type {ReactLane, ReactMeasure, ReactProfilerData} from '../../types';
 import type {Rect, Size} from '../../layout';
 
@@ -239,7 +242,7 @@ export class ReactMeasuresView extends View {
   /**
    * @private
    */
-  _handleHover(interaction: HoverInteraction) {
+  _handleMouseMove(interaction: MouseMoveInteraction) {
     const {
       frame,
       _intrinsicSize,
@@ -299,8 +302,8 @@ export class ReactMeasuresView extends View {
 
   handleInteraction(interaction: Interaction) {
     switch (interaction.type) {
-      case 'hover':
-        this._handleHover(interaction);
+      case 'mousemove':
+        this._handleMouseMove(interaction);
         break;
     }
   }

--- a/src/canvas/views/UserTimingMarksView.js
+++ b/src/canvas/views/UserTimingMarksView.js
@@ -1,6 +1,9 @@
 // @flow
 
-import type {Interaction, HoverInteraction} from '../../useCanvasInteraction';
+import type {
+  Interaction,
+  MouseMoveInteraction,
+} from '../../useCanvasInteraction';
 import type {UserTimingMark} from '../../types';
 import type {Rect, Size} from '../../layout';
 
@@ -178,7 +181,7 @@ export class UserTimingMarksView extends View {
   /**
    * @private
    */
-  _handleHover(interaction: HoverInteraction) {
+  _handleMouseMove(interaction: MouseMoveInteraction) {
     const {frame, onHover, visibleArea} = this;
     if (!onHover) {
       return;
@@ -221,8 +224,8 @@ export class UserTimingMarksView extends View {
 
   handleInteraction(interaction: Interaction) {
     switch (interaction.type) {
-      case 'hover':
-        this._handleHover(interaction);
+      case 'mousemove':
+        this._handleMouseMove(interaction);
         break;
     }
   }

--- a/src/layout/HorizontalPanAndZoomView.js
+++ b/src/layout/HorizontalPanAndZoomView.js
@@ -2,9 +2,9 @@
 
 import type {
   Interaction,
-  HorizontalPanStartInteraction,
-  HorizontalPanMoveInteraction,
-  HorizontalPanEndInteraction,
+  MouseDownInteraction,
+  MouseMoveInteraction,
+  MouseUpInteraction,
   WheelPlainInteraction,
   WheelWithShiftInteraction,
   WheelWithControlInteraction,
@@ -152,13 +152,13 @@ export class HorizontalPanAndZoomView extends View {
     super.layoutSubviews();
   }
 
-  _handleHorizontalPanStart(interaction: HorizontalPanStartInteraction) {
+  _handleMouseDown(interaction: MouseDownInteraction) {
     if (rectContainsPoint(interaction.payload.location, this.frame)) {
       this._isPanning = true;
     }
   }
 
-  _handleHorizontalPanMove(interaction: HorizontalPanMoveInteraction) {
+  _handleMouseMove(interaction: MouseMoveInteraction) {
     if (!this._isPanning) {
       return;
     }
@@ -170,7 +170,7 @@ export class HorizontalPanAndZoomView extends View {
     });
   }
 
-  _handleHorizontalPanEnd(interaction: HorizontalPanEndInteraction) {
+  _handleMouseUp(interaction: MouseUpInteraction) {
     if (this._isPanning) {
       this._isPanning = false;
     }
@@ -246,14 +246,14 @@ export class HorizontalPanAndZoomView extends View {
 
   handleInteraction(interaction: Interaction) {
     switch (interaction.type) {
-      case 'horizontal-pan-start':
-        this._handleHorizontalPanStart(interaction);
+      case 'mousedown':
+        this._handleMouseDown(interaction);
         break;
-      case 'horizontal-pan-move':
-        this._handleHorizontalPanMove(interaction);
+      case 'mousemove':
+        this._handleMouseMove(interaction);
         break;
-      case 'horizontal-pan-end':
-        this._handleHorizontalPanEnd(interaction);
+      case 'mouseup':
+        this._handleMouseUp(interaction);
         break;
       case 'wheel-plain':
         this._handleWheelPlain(interaction);

--- a/src/layout/ResizableSplitView.js
+++ b/src/layout/ResizableSplitView.js
@@ -2,9 +2,9 @@
 
 import type {
   Interaction,
-  VerticalPanStartInteraction,
-  VerticalPanMoveInteraction,
-  VerticalPanEndInteraction,
+  MouseDownInteraction,
+  MouseMoveInteraction,
+  MouseUpInteraction,
 } from '../useCanvasInteraction';
 import type {Rect, Size} from './geometry';
 
@@ -86,7 +86,7 @@ class ResizeBar extends View {
     this._updateColor();
   }
 
-  _handleVerticalPanStart(interaction: VerticalPanStartInteraction) {
+  _handleMouseDown(interaction: MouseDownInteraction) {
     const cursorInView = rectContainsPoint(
       interaction.payload.location,
       this.frame,
@@ -96,7 +96,7 @@ class ResizeBar extends View {
     }
   }
 
-  _handleVerticalPanMove(interaction: VerticalPanMoveInteraction) {
+  _handleMouseMove(interaction: MouseMoveInteraction) {
     const cursorInView = rectContainsPoint(
       interaction.payload.location,
       this.frame,
@@ -107,7 +107,7 @@ class ResizeBar extends View {
     this._setInteractionState(cursorInView ? 'hovered' : 'normal');
   }
 
-  _handleVerticalPanEnd(interaction: VerticalPanEndInteraction) {
+  _handleMouseUp(interaction: MouseUpInteraction) {
     const cursorInView = rectContainsPoint(
       interaction.payload.location,
       this.frame,
@@ -119,14 +119,14 @@ class ResizeBar extends View {
 
   handleInteraction(interaction: Interaction) {
     switch (interaction.type) {
-      case 'vertical-pan-start':
-        this._handleVerticalPanStart(interaction);
+      case 'mousedown':
+        this._handleMouseDown(interaction);
         return;
-      case 'vertical-pan-move':
-        this._handleVerticalPanMove(interaction);
+      case 'mousemove':
+        this._handleMouseMove(interaction);
         return;
-      case 'vertical-pan-end':
-        this._handleVerticalPanEnd(interaction);
+      case 'mouseup':
+        this._handleMouseUp(interaction);
         return;
     }
   }
@@ -268,7 +268,7 @@ export class ResizableSplitView extends View {
     });
   }
 
-  _handleVerticalPanStart(interaction: VerticalPanStartInteraction) {
+  _handleMouseDown(interaction: MouseDownInteraction) {
     const cursorLocation = interaction.payload.location;
     const resizeBarFrame = this._getResizeBar().frame;
     if (rectContainsPoint(cursorLocation, resizeBarFrame)) {
@@ -280,7 +280,7 @@ export class ResizableSplitView extends View {
     }
   }
 
-  _handleVerticalPanMove(interaction: VerticalPanMoveInteraction) {
+  _handleMouseMove(interaction: MouseMoveInteraction) {
     const {_resizingState} = this;
     if (_resizingState) {
       this._resizingState = {
@@ -291,7 +291,7 @@ export class ResizableSplitView extends View {
     }
   }
 
-  _handleVerticalPanEnd(interaction: VerticalPanEndInteraction) {
+  _handleMouseUp(interaction: MouseUpInteraction) {
     if (this._resizingState) {
       this._resizingState = null;
     }
@@ -299,14 +299,14 @@ export class ResizableSplitView extends View {
 
   handleInteraction(interaction: Interaction) {
     switch (interaction.type) {
-      case 'vertical-pan-start':
-        this._handleVerticalPanStart(interaction);
+      case 'mousedown':
+        this._handleMouseDown(interaction);
         return;
-      case 'vertical-pan-move':
-        this._handleVerticalPanMove(interaction);
+      case 'mousemove':
+        this._handleMouseMove(interaction);
         return;
-      case 'vertical-pan-end':
-        this._handleVerticalPanEnd(interaction);
+      case 'mouseup':
+        this._handleMouseUp(interaction);
         return;
     }
   }

--- a/src/layout/VerticalScrollView.js
+++ b/src/layout/VerticalScrollView.js
@@ -2,9 +2,9 @@
 
 import type {
   Interaction,
-  VerticalPanStartInteraction,
-  VerticalPanMoveInteraction,
-  VerticalPanEndInteraction,
+  MouseDownInteraction,
+  MouseMoveInteraction,
+  MouseUpInteraction,
   WheelPlainInteraction,
 } from '../useCanvasInteraction';
 import type {Rect} from './geometry';
@@ -89,13 +89,13 @@ export class VerticalScrollView extends View {
     super.layoutSubviews();
   }
 
-  _handleVerticalPanStart(interaction: VerticalPanStartInteraction) {
+  _handleMouseDown(interaction: MouseDownInteraction) {
     if (rectContainsPoint(interaction.payload.location, this.frame)) {
       this._isPanning = true;
     }
   }
 
-  _handleVerticalPanMove(interaction: VerticalPanMoveInteraction) {
+  _handleMouseMove(interaction: MouseMoveInteraction) {
     if (!this._isPanning) {
       return;
     }
@@ -107,7 +107,7 @@ export class VerticalScrollView extends View {
     });
   }
 
-  _handleVerticalPanEnd(interaction: VerticalPanEndInteraction) {
+  _handleMouseUp(interaction: MouseUpInteraction) {
     if (this._isPanning) {
       this._isPanning = false;
     }
@@ -140,14 +140,14 @@ export class VerticalScrollView extends View {
 
   handleInteraction(interaction: Interaction) {
     switch (interaction.type) {
-      case 'vertical-pan-start':
-        this._handleVerticalPanStart(interaction);
+      case 'mousedown':
+        this._handleMouseDown(interaction);
         break;
-      case 'vertical-pan-move':
-        this._handleVerticalPanMove(interaction);
+      case 'mousemove':
+        this._handleMouseMove(interaction);
         break;
-      case 'vertical-pan-end':
-        this._handleVerticalPanEnd(interaction);
+      case 'mouseup':
+        this._handleMouseUp(interaction);
         break;
       case 'wheel-plain':
         this._handleWheelPlain(interaction);

--- a/src/useCanvasInteraction.js
+++ b/src/useCanvasInteraction.js
@@ -4,50 +4,22 @@ import type {Point} from './layout';
 
 import {useEffect} from 'react';
 
-export type VerticalPanStartInteraction = {|
-  type: 'vertical-pan-start',
+export type MouseDownInteraction = {|
+  type: 'mousedown',
   payload: {|
     event: MouseEvent,
     location: Point,
   |},
 |};
-export type VerticalPanMoveInteraction = {|
-  type: 'vertical-pan-move',
+export type MouseMoveInteraction = {|
+  type: 'mousemove',
   payload: {|
     event: MouseEvent,
     location: Point,
   |},
 |};
-export type VerticalPanEndInteraction = {|
-  type: 'vertical-pan-end',
-  payload: {|
-    event: MouseEvent,
-    location: Point,
-  |},
-|};
-export type HorizontalPanStartInteraction = {|
-  type: 'horizontal-pan-start',
-  payload: {|
-    event: MouseEvent,
-    location: Point,
-  |},
-|};
-export type HorizontalPanMoveInteraction = {|
-  type: 'horizontal-pan-move',
-  payload: {|
-    event: MouseEvent,
-    location: Point,
-  |},
-|};
-export type HorizontalPanEndInteraction = {|
-  type: 'horizontal-pan-end',
-  payload: {|
-    event: MouseEvent,
-    location: Point,
-  |},
-|};
-export type HoverInteraction = {|
-  type: 'hover',
+export type MouseUpInteraction = {|
+  type: 'mouseup',
   payload: {|
     event: MouseEvent,
     location: Point,
@@ -83,13 +55,9 @@ export type WheelWithMetaInteraction = {|
 |};
 
 export type Interaction =
-  | VerticalPanStartInteraction
-  | VerticalPanMoveInteraction
-  | VerticalPanEndInteraction
-  | HorizontalPanStartInteraction
-  | HorizontalPanMoveInteraction
-  | HorizontalPanEndInteraction
-  | HoverInteraction
+  | MouseDownInteraction
+  | MouseMoveInteraction
+  | MouseUpInteraction
   | WheelPlainInteraction
   | WheelWithShiftInteraction
   | WheelWithControlInteraction
@@ -120,14 +88,7 @@ export function useCanvasInteraction(
 
     const onCanvasMouseDown: MouseEventHandler = event => {
       interactor({
-        type: 'horizontal-pan-start',
-        payload: {
-          event,
-          location: localToCanvasCoordinates({x: event.x, y: event.y}),
-        },
-      });
-      interactor({
-        type: 'vertical-pan-start',
+        type: 'mousedown',
         payload: {
           event,
           location: localToCanvasCoordinates({x: event.x, y: event.y}),
@@ -137,21 +98,7 @@ export function useCanvasInteraction(
 
     const onCanvasMouseMove: MouseEventHandler = event => {
       interactor({
-        type: 'horizontal-pan-move',
-        payload: {
-          event,
-          location: localToCanvasCoordinates({x: event.x, y: event.y}),
-        },
-      });
-      interactor({
-        type: 'vertical-pan-move',
-        payload: {
-          event,
-          location: localToCanvasCoordinates({x: event.x, y: event.y}),
-        },
-      });
-      interactor({
-        type: 'hover',
+        type: 'mousemove',
         payload: {
           event,
           location: localToCanvasCoordinates({x: event.x, y: event.y}),
@@ -161,14 +108,7 @@ export function useCanvasInteraction(
 
     const onDocumentMouseUp: MouseEventHandler = event => {
       interactor({
-        type: 'horizontal-pan-end',
-        payload: {
-          event,
-          location: localToCanvasCoordinates({x: event.x, y: event.y}),
-        },
-      });
-      interactor({
-        type: 'vertical-pan-end',
+        type: 'mouseup',
         payload: {
           event,
           location: localToCanvasCoordinates({x: event.x, y: event.y}),


### PR DESCRIPTION
Turns out separating vertical pans, horizontal pans, and hover interactions was not necessary. This PR replaces them with mouse interactions that correspond directly to DOM mouse events.