### PR TITLE
Listen to mouse move events when dragging offscreen

### DIFF
--- a/src/useCanvasInteraction.js
+++ b/src/useCanvasInteraction.js
@@ -135,7 +135,7 @@ export function useCanvasInteraction(
       });
     };
 
-    const onCanvasMouseMove: MouseEventHandler = event => {
+    const onDocumentMouseMove: MouseEventHandler = event => {
       interactor({
         type: 'horizontal-pan-move',
         payload: {
@@ -217,18 +217,18 @@ export function useCanvasInteraction(
       return false;
     };
 
+    document.addEventListener('mousemove', onDocumentMouseMove);
     document.addEventListener('mouseup', onDocumentMouseUp);
 
-    canvas.addEventListener('wheel', onCanvasWheel);
     canvas.addEventListener('mousedown', onCanvasMouseDown);
-    canvas.addEventListener('mousemove', onCanvasMouseMove);
+    canvas.addEventListener('wheel', onCanvasWheel);
 
     return () => {
+      document.removeEventListener('mousemove', onDocumentMouseMove);
       document.removeEventListener('mouseup', onDocumentMouseUp);
 
-      canvas.removeEventListener('wheel', onCanvasWheel);
       canvas.removeEventListener('mousedown', onCanvasMouseDown);
-      canvas.removeEventListener('mousemove', onCanvasMouseMove);
+      canvas.removeEventListener('wheel', onCanvasWheel);
     };
   }, [canvasRef, interactor]);
 }


### PR DESCRIPTION
It was annoying that the canvas stopped panning if your cursor went outside the bounds of the canvas while you were dragging. This PR allows us to continue to listen to these mouse move events.

This behavior is also used in other apps such as Google Maps, and I think it provides a better UX.

### Test Plan

1. Reduce the size of your window such that it does not take up your screen.
1. Start dragging on the canvas.
1. Continue dragging until the cursor moves offscreen. The canvas should continue panning.