### PR TITLE
Fix tooltip

### DIFF
--- a/src/CanvasPage.css
+++ b/src/CanvasPage.css
@@ -4,5 +4,4 @@
   bottom: 0.5rem;
   left: 0.5rem;
   right: 0.5rem;
-  overflow: hidden;
 }

--- a/src/CanvasPage.js
+++ b/src/CanvasPage.js
@@ -251,25 +251,19 @@ function AutoSizedCanvas({data, height, width}: AutoSizedCanvasProps) {
 
   const interactor = useCallback(
     interaction => {
-      if (
-        hoveredEvent &&
-        (hoveredEvent.event ||
-          hoveredEvent.measure ||
-          hoveredEvent.flamechartStackFrame ||
-          hoveredEvent.userTimingMark)
-      ) {
-        setMouseLocation({
-          x: interaction.payload.event.x,
-          y: interaction.payload.event.y,
-        });
-      }
       if (canvasRef.current === null) {
         return;
       }
       surfaceRef.current.handleInteraction(interaction);
-      surfaceRef.current.displayIfNeeded();
+      // Defer drawing to canvas until React's commit phase, to avoid drawing
+      // twice and to ensure that both the canvas and DOM elements managed by
+      // React are in sync.
+      setMouseLocation({
+        x: interaction.payload.event.x,
+        y: interaction.payload.event.y,
+      });
     },
-    [surfaceRef, hoveredEvent, setMouseLocation],
+    [surfaceRef, canvasRef, hoveredEvent, setMouseLocation],
   );
 
   useCanvasInteraction(canvasRef, interactor);
@@ -388,10 +382,7 @@ function AutoSizedCanvas({data, height, width}: AutoSizedCanvasProps) {
     hoveredEvent,
   ]);
 
-  // When React component renders, rerender surface.
-  // TODO: See if displaying on rAF would make more sense since we're somewhat
-  // decoupled from React and we don't want to render canvas multiple times per
-  // frame.
+  // Draw to canvas in React's commit phase
   useLayoutEffect(() => {
     surfaceRef.current.displayIfNeeded();
   });

--- a/src/EventTooltip.css
+++ b/src/EventTooltip.css
@@ -1,5 +1,5 @@
 .Tooltip {
-  position: absolute;
+  position: fixed;
   display: inline-block;
   border-radius: 0.125rem;
   max-width: 300px;
@@ -31,12 +31,20 @@
 }
 
 .DetailsGridURL {
+  word-break: break-all;
+  max-height: 50vh;
   overflow: hidden;
+}
+
+.FlamechartStackFrameName {
+  word-break: break-word;
+  margin-left: 0.4rem;
 }
 
 .ComponentName {
   font-weight: bold;
-  word-wrap: break-word;
+  word-break: break-word;
+  margin-right: 0.4rem;
 }
 
 .ComponentStack {
@@ -60,4 +68,12 @@
   );
   white-space: pre;
   --gradient-height: 5em;
+}
+
+.ReactMeasureLabel {
+  margin-left: 0.4rem;
+}
+
+.UserTimingLabel {
+  word-break: break-word;
 }

--- a/src/EventTooltip.js
+++ b/src/EventTooltip.js
@@ -32,6 +32,13 @@ function formatDuration(ms) {
   return prettyMilliseconds(ms, {millisecondsDecimalDigits: 3});
 }
 
+function trimmedString(string: string, length: number): string {
+  if (string.length > length) {
+    return `${string.substr(0, length - 1)}…`;
+  }
+  return string;
+}
+
 function getReactEventLabel(type): string | null {
   switch (type) {
     case 'schedule-render':
@@ -194,7 +201,7 @@ const TooltipReactEvent = ({
     <div className={styles.Tooltip} ref={tooltipRef}>
       {componentName && (
         <span className={styles.ComponentName} style={{color}}>
-          {componentName}
+          {trimmedString(componentName, 768)}
         </span>
       )}
       {label}

--- a/src/EventTooltip.js
+++ b/src/EventTooltip.js
@@ -32,13 +32,6 @@ function formatDuration(ms) {
   return prettyMilliseconds(ms, {millisecondsDecimalDigits: 3});
 }
 
-function trimComponentName(name) {
-  if (name.length > 128) {
-    return name.substring(0, 127) + '...';
-  }
-  return name;
-}
-
 function getReactEventLabel(type): string | null {
   switch (type) {
     case 'schedule-render':
@@ -201,7 +194,7 @@ const TooltipReactEvent = ({
     <div className={styles.Tooltip} ref={tooltipRef}>
       {componentName && (
         <span className={styles.ComponentName} style={{color}}>
-          {trimComponentName(componentName)}
+          {componentName}
         </span>
       )}
       {label}

--- a/src/EventTooltip.js
+++ b/src/EventTooltip.js
@@ -157,7 +157,8 @@ const TooltipFlamechartNode = ({
   } = stackFrame;
   return (
     <div className={styles.Tooltip} ref={tooltipRef}>
-      {formatDuration(duration)} {trimComponentName(name)}
+      {formatDuration(duration)}
+      <span className={styles.FlamechartStackFrameName}>{name}</span>
       <div className={styles.DetailsGrid}>
         <div className={styles.DetailsGridLabel}>Timestamp:</div>
         <div>{formatTimestamp(timestamp)}</div>
@@ -202,7 +203,7 @@ const TooltipReactEvent = ({
         <span className={styles.ComponentName} style={{color}}>
           {trimComponentName(componentName)}
         </span>
-      )}{' '}
+      )}
       {label}
       <div className={styles.Divider} />
       <div className={styles.DetailsGrid}>
@@ -241,7 +242,8 @@ const TooltipReactMeasure = ({
 
   return (
     <div className={styles.Tooltip} ref={tooltipRef}>
-      {formatDuration(duration)} {label}
+      {formatDuration(duration)}
+      <span className={styles.ReactMeasureLabel}>{label}</span>
       <div className={styles.Divider} />
       <div className={styles.DetailsGrid}>
         <div className={styles.DetailsGridLabel}>Timestamp:</div>
@@ -267,7 +269,7 @@ const TooltipUserTimingMark = ({
   const {name, timestamp} = mark;
   return (
     <div className={styles.Tooltip} ref={tooltipRef}>
-      {name}
+      <span className={styles.UserTimingLabel}>{name}</span>
       <div className={styles.Divider} />
       <div className={styles.DetailsGrid}>
         <div className={styles.DetailsGridLabel}>Timestamp:</div>

--- a/src/EventTooltip.js
+++ b/src/EventTooltip.js
@@ -39,7 +39,7 @@ function trimComponentName(name) {
   return name;
 }
 
-function getReactEventLabel(type) {
+function getReactEventLabel(type): string | null {
   switch (type) {
     case 'schedule-render':
       return 'render scheduled';
@@ -58,7 +58,25 @@ function getReactEventLabel(type) {
   }
 }
 
-function getReactMeasureLabel(type: string) {
+function getReactEventColor(event: ReactEvent): string | null {
+  switch (event.type) {
+    case 'schedule-render':
+      return COLORS.REACT_SCHEDULE_HOVER;
+    case 'schedule-state-update':
+    case 'schedule-force-update':
+      return event.isCascading
+        ? COLORS.REACT_SCHEDULE_CASCADING_HOVER
+        : COLORS.REACT_SCHEDULE_HOVER;
+    case 'suspense-suspend':
+    case 'suspense-resolved':
+    case 'suspense-rejected':
+      return COLORS.REACT_SUSPEND_HOVER;
+    default:
+      return null;
+  }
+}
+
+function getReactMeasureLabel(type): string | null {
   switch (type) {
     case 'commit':
       return 'commit';
@@ -85,65 +103,18 @@ export default function EventTooltip({data, hoveredEvent, origin}: Props) {
     return null;
   }
 
-  const {event, flamechartStackFrame, measure, userTimingMark} = hoveredEvent;
+  const {event, measure, flamechartStackFrame, userTimingMark} = hoveredEvent;
 
   if (event !== null) {
-    switch (event.type) {
-      case 'schedule-render':
-        return (
-          <TooltipReactEvent
-            color={COLORS.REACT_SCHEDULE_HOVER}
-            data={data}
-            event={event}
-            tooltipRef={tooltipRef}
-          />
-        );
-      case 'schedule-state-update': // eslint-disable-line no-case-declarations
-      case 'schedule-force-update':
-        const color = event.isCascading
-          ? COLORS.REACT_SCHEDULE_CASCADING_HOVER
-          : COLORS.REACT_SCHEDULE_HOVER;
-        return (
-          <TooltipReactEvent
-            color={color}
-            data={data}
-            event={event}
-            tooltipRef={tooltipRef}
-          />
-        );
-      case 'suspense-suspend':
-      case 'suspense-resolved':
-      case 'suspense-rejected':
-        return (
-          <TooltipReactEvent
-            color={COLORS.REACT_SUSPEND_HOVER}
-            data={data}
-            event={event}
-            tooltipRef={tooltipRef}
-          />
-        );
-      default:
-        console.warn(`Unexpected event type "${event.type}"`);
-        break;
-    }
+    return <TooltipReactEvent event={event} tooltipRef={tooltipRef} />;
   } else if (measure !== null) {
-    switch (measure.type) {
-      case 'commit':
-      case 'render-idle':
-      case 'render':
-      case 'layout-effects':
-      case 'passive-effects':
-        return (
-          <TooltipReactMeasure
-            data={data}
-            measure={measure}
-            tooltipRef={tooltipRef}
-          />
-        );
-      default:
-        console.warn(`Unexpected measure type "${measure.type}"`);
-        break;
-    }
+    return (
+      <TooltipReactMeasure
+        data={data}
+        measure={measure}
+        tooltipRef={tooltipRef}
+      />
+    );
   } else if (flamechartStackFrame !== null) {
     return (
       <TooltipFlamechartNode
@@ -210,16 +181,20 @@ const TooltipFlamechartNode = ({
 };
 
 const TooltipReactEvent = ({
-  color,
   event,
   tooltipRef,
 }: {
-  color: string,
   event: ReactEvent,
   tooltipRef: Return<typeof useRef>,
 }) => {
-  const {componentName, componentStack, timestamp, type} = event;
-  const label = getReactEventLabel(type);
+  const label = getReactEventLabel(event.type);
+  const color = getReactEventColor(event);
+  if (!label || !color) {
+    console.warn(`Unexpected event type "${event.type}"`);
+    return null;
+  }
+
+  const {componentName, componentStack, timestamp} = event;
 
   return (
     <div className={styles.Tooltip} ref={tooltipRef}>
@@ -255,8 +230,13 @@ const TooltipReactMeasure = ({
   measure: ReactMeasure,
   tooltipRef: Return<typeof useRef>,
 }) => {
-  const {batchUID, duration, timestamp, type, lanes} = measure;
-  const label = getReactMeasureLabel(type);
+  const label = getReactMeasureLabel(measure.type);
+  if (!label) {
+    console.warn(`Unexpected measure type "${measure.type}"`);
+    return null;
+  }
+
+  const {batchUID, duration, timestamp, lanes} = measure;
   const [startTime, stopTime] = getBatchRange(batchUID, data);
 
   return (

--- a/src/utils/useSmartTooltip.js
+++ b/src/utils/useSmartTooltip.js
@@ -57,7 +57,7 @@ export default function useSmartTooltip({
         element.style.left = `${mouseX + TOOLTIP_OFFSET}px`;
       }
     }
-  });
+  }, [mouseX, mouseY, ref]);
 
   return ref;
 }


### PR DESCRIPTION
Fixes #87, and refixes #47 with a solution that solves its root cause.

Details and summary of changes in commit messages.

### Test Plan

* `yarn flow`: no new errors
* CI
* `yarn start`:
	* #87 can no longer be reproduced
	* Tooltip no longer travels beyond the bounds of the page
	* Larger gap between function names and timestamps, and component names and labels. This matches Chrome's tooltips.
	* Fix display of long function names
	* Allow display of long script URLs
		|Before|After|
		|-|-|
		|![image](https://user-images.githubusercontent.com/12784593/89543012-fcd4f280-d832-11ea-99fd-bda6cb9ba9e9.png)|![image](https://user-images.githubusercontent.com/12784593/89543177-30b01800-d833-11ea-85c9-ba3861db452c.png)|
	* Script URLs now limited in height to `50vh`
		|Height not limited|Height limited|
		|-|-|
		|![image](https://user-images.githubusercontent.com/12784593/89543854-0a3eac80-d834-11ea-89f8-d1f2f4367138.png)|![image](https://user-images.githubusercontent.com/12784593/89543951-20e50380-d834-11ea-9a98-d105e8a90ab0.png)|
	* Disable truncation of React component names (rationale in commit message, but TL;DR I don't think people will use unreasonably long names because the source code will be a pain to deal with) (no change in these screenshots, because the React component names were limited to 128 chars to accommodate this particular profile)
		|Before|After|
		|-|-|
		|![image](https://user-images.githubusercontent.com/12784593/89543576-b03de700-d833-11ea-9e43-5b7bc1888bfe.png)|![image](https://user-images.githubusercontent.com/12784593/89543455-8be20a80-d833-11ea-84a6-6ccf45a32a82.png)|