### PR TITLE
Switch to concurrent React

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "memoize-one": "^5.1.1",
     "nullthrows": "^1.1.1",
     "pretty-ms": "^7.0.0",
-    "react": "^16.13.1",
-    "react-dom": "^16.13.1",
+    "react": "experimental",
+    "react-dom": "experimental",
     "react-virtualized-auto-sizer": "^1.0.2",
     "scheduler": "^0.19.1"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,12 @@
 import React from 'react';
-import {render} from 'react-dom';
+import {unstable_createRoot as createRoot} from 'react-dom';
 import App from './App';
 import './index.css';
 
 const container = document.getElementById('root');
 
-render(
+createRoot(container).render(
   <React.StrictMode>
     <App />
   </React.StrictMode>,
-  container,
 );

--- a/yarn.lock
+++ b/yarn.lock
@@ -8984,15 +8984,14 @@ randomfill@^1.0.3:
     randombytes "^2.0.5"
     safe-buffer "^5.1.0"
 
-react-dom@^16.13.1:
-  version "16.13.1"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.13.1.tgz#c1bd37331a0486c078ee54c4740720993b2e0e7f"
-  integrity sha512-81PIMmVLnCNLO/fFOQxdQkvEq/+Hfpv24XNJfpyZhTRfO0QcmQIF/PgCa1zCOj2w1hrn12MFLyaJ/G0+Mxtfag==
+react-dom@experimental:
+  version "0.0.0-experimental-3d0895557"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-0.0.0-experimental-3d0895557.tgz#8fdb08f45c461fa38fbc8a4b458450abcd10910b"
+  integrity sha512-rb88BTYlEfDbZ+1TlRKGDUflKGJWptlXKUv+4jI+LM91mr6idkWGf+3U92m7hb09aYvlHozt7slrGV3P5XuFGg==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-    prop-types "^15.6.2"
-    scheduler "^0.19.1"
+    scheduler "0.0.0-experimental-3d0895557"
 
 react-is@^16.12.0:
   version "16.13.1"
@@ -9031,6 +9030,14 @@ react@^16.7.0:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
+
+react@experimental:
+  version "0.0.0-experimental-3d0895557"
+  resolved "https://registry.yarnpkg.com/react/-/react-0.0.0-experimental-3d0895557.tgz#0c6c95681bf93e023f74a5448f2261ba99b41c01"
+  integrity sha512-/5nwNTI6QypTthi9rRbf74i/ac6UTf3syRrgJpkzV52470aNlF+Qq6D6e7kFiPpcfh3A/V6vnMCPtmB/rNnElA==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
 
 read-pkg-up@^7.0.1:
   version "7.0.1"
@@ -9487,6 +9494,14 @@ saxes@^5.0.0:
   integrity sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==
   dependencies:
     xmlchars "^2.2.0"
+
+scheduler@0.0.0-experimental-3d0895557:
+  version "0.0.0-experimental-3d0895557"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.0.0-experimental-3d0895557.tgz#ad5e191e8f13d4b61e52d3fce0a6a42a769eacd7"
+  integrity sha512-6ZRZa9aolgD+1y2w/vagSzXeoAMllKNBgrVLWdlP2uAHYRsmOQaAkOedqrtEFnqDg/k0SI+uvUhYe5BWOtzFkQ==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
 
 scheduler@^0.19.1:
   version "0.19.1"


### PR DESCRIPTION
Since we intend to move this project into the React codebase, I figured it'll be a good idea to upgrade us to React experimental and enable concurrent mode. This should ensure that we're closer to React master and reduce the chance of any unlikely integration issues.

Stacked on top of #121, because #121 includes fixes to ensure that the canvas is drawn together with React's commit phase, preventing the tooltip from lagging behind the canvas drawing when concurrent mode is enabled (a disorienting UX).

Also results in a qualitatively smoother scrolling experience (working towards #50 again). By some eyeball estimating, it looks like this PR is getting frame rates in the mid-to-high 20s, whereas #121 is getting around 19-20 FPS when scrolled to the same place.

### Test Plan

* `yarn upgrade`
* `yarn flow`: no new errors
* CI