### PR TITLE
Reimplement zoom to batch

### DIFF
--- a/src/CanvasPage.js
+++ b/src/CanvasPage.js
@@ -86,25 +86,24 @@ const copySummary = (data, measure) => {
   );
 };
 
-// TODO: Migrate zoomToBatch to new views architecture
-// const zoomToBatch = (data, measure, state) => {
-//   const {zoomTo} = state;
-//   if (!zoomTo) {
-//     return;
-//   }
-//   const {batchUID} = measure;
-//   const [startTime, stopTime] = getBatchRange(batchUID, data);
-//   zoomTo(startTime, stopTime);
-// };
-
 const syncedHorizontalPanAndZoomViews: HorizontalPanAndZoomView[] = [];
 const syncAllHorizontalPanAndZoomViewStates: HorizontalPanAndZoomViewOnChangeCallback = (
   newState,
-  view,
+  view?: HorizontalPanAndZoomView,
 ) => {
   syncedHorizontalPanAndZoomViews.forEach(
     syncedView =>
       view !== syncedView && syncedView.setPanAndZoomState(newState),
+  );
+};
+
+const zoomToBatch = (data, measure) => {
+  const {batchUID} = measure;
+  const [startTime, stopTime] = getBatchRange(batchUID, data);
+  syncedHorizontalPanAndZoomViews.forEach(syncedView =>
+    // Using time as range works because the views' intrinsic content size is
+    // based on time.
+    syncedView.zoomToRange(startTime, stopTime),
   );
 };
 
@@ -425,13 +424,13 @@ function AutoSizedCanvas({data, height, width}: AutoSizedCanvasProps) {
                   Copy component stack
                 </ContextMenuItem>
               )}
-              {/* {measure !== null && (
+              {measure !== null && (
                 <ContextMenuItem
-                  onClick={() => zoomToBatch(contextData.data, measure, state)}
+                  onClick={() => zoomToBatch(contextData.data, measure)}
                   title="Zoom to batch">
                   Zoom to batch
                 </ContextMenuItem>
-              )} */}
+              )}
               {measure !== null && (
                 <ContextMenuItem
                   onClick={() => copySummary(contextData.data, measure)}


### PR DESCRIPTION
Closes #84.

Adds a `zoomToRange` method to `HorizontalPanAndZoomView`, modeled after `UIScrollView`'s [`zoomToRect:animated:` method](https://developer.apple.com/documentation/uikit/uiscrollview/1619388-zoomtorect?language=objc)

### Test Plan

* `yarn flow`: no new errors
* CI
* `yarn start`:
	![image](https://user-images.githubusercontent.com/12784593/89553699-71faf480-d840-11ea-883e-e4e05ba6de96.png)
	![image](https://user-images.githubusercontent.com/12784593/89553771-8808b500-d840-11ea-885a-6c19428d5aa9.png)

I suspect there's a bug in our batch duration calculation, because the zoom to method often zooms to an empty space. This is not a bug in the zooming: the view is zoomed to a range that matches the batch duration displayed in the tooltip. I'll file an issue for this tomorrow.

![image](https://user-images.githubusercontent.com/12784593/89553912-b9818080-d840-11ea-938f-9a184c71abe4.png)
