### PR TITLE
[Import Prep][6/n] Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,8 @@
 {
-  "name": "scheduling-profiler-prototype",
+  "private": true,
+  "name": "react-scheduling-profiler",
   "version": "0.0.1",
+  "license": "MIT",
   "scripts": {
     "build": "parcel build --no-cache index.html",
     "prettier": "prettier --write \"**/*.{js,json,css}\"",
@@ -8,8 +10,6 @@
     "lint": "eslint \"src/**/*.js\"",
     "test": "jest"
   },
-  "author": "Brian Vaughn <bvaughn@fb.com>",
-  "license": "MIT",
   "dependencies": {
     "@elg/speedscope": "1.9.0-c46bbab",
     "array-binsearch": "^1.0.1",


### PR DESCRIPTION
Stack PR by [STACK ATTACK](https://github.com/taneliang/stack-attack):
- #128 [Import Prep][1/n] Upgrade dependencies
- #129 [Import Prep][2/n] Remove graveyard
- #130 [Import Prep][3/n] Remove unnecessary sample profiles
- #133 [Import Prep][4/n] Fix Flow errors
- #131 [Import Prep][5/n] Deduplicate clamp, cleanup TODOs
- **#132 [Import Prep][6/n] Update package.json**
- #127 [Import Prep][7/n] Fix indeterministic test mark ordering

Update package.json to match React DevTools packages:

* Set package to private to prevent publishing to NPM
* Rename package to match the final `react-scheduling-profiler` folder
* Remove author

When moved into the React repo, we'll also need to remove React
packages from dependencies, but we can't do that now.